### PR TITLE
fix(background): stabilize android permission request logic

### DIFF
--- a/.codesight/CODESIGHT.md
+++ b/.codesight/CODESIGHT.md
@@ -4,7 +4,7 @@
 
 > 0 routes | 0 models | 39 components | 58 lib files | 3 env vars | 1 middleware | 0% test coverage
 > **Token savings:** this file is ~6.300 tokens. Without it, AI exploration would cost ~37.500 tokens. **Saves ~31.200 tokens per conversation.**
-> **Last scanned:** 2026-05-03 07:17 — re-run after significant changes
+> **Last scanned:** 2026-05-03 08:00 — re-run after significant changes
 
 ---
 

--- a/.codesight/CODESIGHT.md
+++ b/.codesight/CODESIGHT.md
@@ -4,7 +4,7 @@
 
 > 0 routes | 0 models | 39 components | 58 lib files | 3 env vars | 1 middleware | 0% test coverage
 > **Token savings:** this file is ~6.300 tokens. Without it, AI exploration would cost ~37.500 tokens. **Saves ~31.200 tokens per conversation.**
-> **Last scanned:** 2026-05-03 08:00 — re-run after significant changes
+> **Last scanned:** 2026-05-03 08:10 — re-run after significant changes
 
 ---
 
@@ -324,6 +324,7 @@
 - `src\utils\theme.ts` — imported by **37** files
 - `src\store\useAppStore.ts` — imported by **33** files
 - `src\notifications\notificationManager.ts` — imported by **13** files
+- `src\detection\PermissionService.ts` — imported by **13** files
 - `src\storage\StorageService.ts` — imported by **11** files
 - `src\components\ResponsiveGridList.tsx` — imported by **11** files
 - `src\utils\helpers.ts` — imported by **10** files
@@ -337,7 +338,6 @@
 - `src\detection\sessionMerger.ts` — imported by **7** files
 - `src\weather\weatherService.ts` — imported by **7** files
 - `src\hooks\useTheme.ts` — imported by **6** files
-- `src\detection\PermissionService.ts` — imported by **6** files
 - `src\calendar\calendarService.ts` — imported by **6** files
 - `src\utils\constants.ts` — imported by **6** files
 - `src\navigation\AppNavigator.tsx` — imported by **5** files
@@ -347,20 +347,20 @@
 - `src\utils\theme.ts` ← `src\background\smartReminderTask.ts`, `src\components\DiagnosticSheet.tsx`, `src\components\EditLocationSheet.tsx`, `src\components\EditSessionSheet.tsx`, `src\components\ErrorBoundary.tsx` +32 more
 - `src\store\useAppStore.ts` ← `App.tsx`, `src\components\DiagnosticSheet.tsx`, `src\components\EditLocationSheet.tsx`, `src\components\EditSessionSheet.tsx`, `src\components\ErrorBoundary.tsx` +28 more
 - `src\notifications\notificationManager.ts` ← `src\background\smartReminderTask.ts`, `src\hooks\useForegroundSync.ts`, `src\hooks\useGoalIntegrations.ts`, `src\notifications\services\ReminderQueueManager.ts`, `src\notifications\services\SmartReminderScheduler.ts` +8 more
+- `src\detection\PermissionService.ts` ← `src\detection\gpsDetection.ts`, `src\detection\healthConnect.ts`, `src\detection\index.ts`, `src\hooks\useDetectionSettings.ts`, `src\screens\IntroScreen.tsx` +8 more
 - `src\storage\StorageService.ts` ← `src\background\smartReminderTask.ts`, `src\core\container.ts`, `src\notifications\services\NotificationResponseHandler.ts`, `src\notifications\services\ReminderMessageBuilder.ts`, `src\notifications\services\ReminderQueueManager.ts` +6 more
 - `src\components\ResponsiveGridList.tsx` ← `src\screens\AboutAppScreen.tsx`, `src\screens\ActivityLogScreen.tsx`, `src\screens\EventsScreen.tsx`, `src\screens\FeedbackSupportScreen.tsx`, `src\screens\GoalsScreen.tsx` +6 more
 - `src\utils\helpers.ts` ← `src\components\EditSessionSheet.tsx`, `src\components\ManualSessionSheet.tsx`, `src\components\ProgressRing.tsx`, `src\components\ReminderFeedbackModal.tsx`, `src\i18n\index.ts` +5 more
 - `src\storage\db.ts` ← `src\storage\index.ts`, `src\storage\repositories\GoalRepository.ts`, `src\storage\repositories\LocationRepository.ts`, `src\storage\repositories\LogRepository.ts`, `src\storage\repositories\NotificationRepository.ts` +5 more
 - `src\utils\widgetHelper.ts` ← `appBootstrap.ts`, `src\background\smartReminderTask.ts`, `src\hooks\useForegroundSync.ts`, `src\screens\EventsScreen.tsx`, `src\widget\widget-task-handler.tsx` +4 more
 - `src\utils\sessionsChangedEmitter.ts` ← `src\background\geofenceTask.ts`, `src\detection\HealthSessionBuilder.ts`, `src\detection\LocationTracker.ts`, `src\navigation\AppNavigator.tsx`, `src\screens\EventsScreen.tsx` +4 more
-- `src\storage\types.ts` ← `src\domain\SessionDomain.ts`, `src\storage\index.ts`, `src\storage\repositories\GoalRepository.ts`, `src\storage\repositories\LocationRepository.ts`, `src\storage\repositories\LogRepository.ts` +4 more
 
 ---
 
 # Test Coverage
 
 > **0%** of routes and models are covered by tests
-> 66 test files found
+> 68 test files found
 
 ---
 

--- a/.codesight/coverage.md
+++ b/.codesight/coverage.md
@@ -1,4 +1,4 @@
 # Test Coverage
 
 > **0%** of routes and models are covered by tests
-> 66 test files found
+> 68 test files found

--- a/.codesight/graph.md
+++ b/.codesight/graph.md
@@ -5,6 +5,7 @@
 - `src\utils\theme.ts` — imported by **37** files
 - `src\store\useAppStore.ts` — imported by **33** files
 - `src\notifications\notificationManager.ts` — imported by **13** files
+- `src\detection\PermissionService.ts` — imported by **13** files
 - `src\storage\StorageService.ts` — imported by **11** files
 - `src\components\ResponsiveGridList.tsx` — imported by **11** files
 - `src\utils\helpers.ts` — imported by **10** files
@@ -18,7 +19,6 @@
 - `src\detection\sessionMerger.ts` — imported by **7** files
 - `src\weather\weatherService.ts` — imported by **7** files
 - `src\hooks\useTheme.ts` — imported by **6** files
-- `src\detection\PermissionService.ts` — imported by **6** files
 - `src\calendar\calendarService.ts` — imported by **6** files
 - `src\utils\constants.ts` — imported by **6** files
 - `src\navigation\AppNavigator.tsx` — imported by **5** files
@@ -28,10 +28,10 @@
 - `src\utils\theme.ts` ← `src\background\smartReminderTask.ts`, `src\components\DiagnosticSheet.tsx`, `src\components\EditLocationSheet.tsx`, `src\components\EditSessionSheet.tsx`, `src\components\ErrorBoundary.tsx` +32 more
 - `src\store\useAppStore.ts` ← `App.tsx`, `src\components\DiagnosticSheet.tsx`, `src\components\EditLocationSheet.tsx`, `src\components\EditSessionSheet.tsx`, `src\components\ErrorBoundary.tsx` +28 more
 - `src\notifications\notificationManager.ts` ← `src\background\smartReminderTask.ts`, `src\hooks\useForegroundSync.ts`, `src\hooks\useGoalIntegrations.ts`, `src\notifications\services\ReminderQueueManager.ts`, `src\notifications\services\SmartReminderScheduler.ts` +8 more
+- `src\detection\PermissionService.ts` ← `src\detection\gpsDetection.ts`, `src\detection\healthConnect.ts`, `src\detection\index.ts`, `src\hooks\useDetectionSettings.ts`, `src\screens\IntroScreen.tsx` +8 more
 - `src\storage\StorageService.ts` ← `src\background\smartReminderTask.ts`, `src\core\container.ts`, `src\notifications\services\NotificationResponseHandler.ts`, `src\notifications\services\ReminderMessageBuilder.ts`, `src\notifications\services\ReminderQueueManager.ts` +6 more
 - `src\components\ResponsiveGridList.tsx` ← `src\screens\AboutAppScreen.tsx`, `src\screens\ActivityLogScreen.tsx`, `src\screens\EventsScreen.tsx`, `src\screens\FeedbackSupportScreen.tsx`, `src\screens\GoalsScreen.tsx` +6 more
 - `src\utils\helpers.ts` ← `src\components\EditSessionSheet.tsx`, `src\components\ManualSessionSheet.tsx`, `src\components\ProgressRing.tsx`, `src\components\ReminderFeedbackModal.tsx`, `src\i18n\index.ts` +5 more
 - `src\storage\db.ts` ← `src\storage\index.ts`, `src\storage\repositories\GoalRepository.ts`, `src\storage\repositories\LocationRepository.ts`, `src\storage\repositories\LogRepository.ts`, `src\storage\repositories\NotificationRepository.ts` +5 more
 - `src\utils\widgetHelper.ts` ← `appBootstrap.ts`, `src\background\smartReminderTask.ts`, `src\hooks\useForegroundSync.ts`, `src\screens\EventsScreen.tsx`, `src\widget\widget-task-handler.tsx` +4 more
 - `src\utils\sessionsChangedEmitter.ts` ← `src\background\geofenceTask.ts`, `src\detection\HealthSessionBuilder.ts`, `src\detection\LocationTracker.ts`, `src\navigation\AppNavigator.tsx`, `src\screens\EventsScreen.tsx` +4 more
-- `src\storage\types.ts` ← `src\domain\SessionDomain.ts`, `src\storage\index.ts`, `src\storage\repositories\GoalRepository.ts`, `src\storage\repositories\LocationRepository.ts`, `src\storage\repositories\LogRepository.ts` +4 more

--- a/.codesight/wiki/log.md
+++ b/.codesight/wiki/log.md
@@ -2,8 +2,6 @@
 
 History of `npx codesight --wiki` runs. Capped at 20 entries.
 
-## [2026-05-02 17:10:41] scan | 0 routes, 0 models, 39 components → 4 articles
-
 ## [2026-05-02 17:11:26] scan | 0 routes, 0 models, 39 components → 4 articles
 
 ## [2026-05-02 17:14:13] scan | 0 routes, 0 models, 39 components → 4 articles
@@ -41,3 +39,5 @@ History of `npx codesight --wiki` runs. Capped at 20 entries.
 ## [2026-05-03 07:17:32] scan | 0 routes, 0 models, 39 components → 4 articles
 
 ## [2026-05-03 08:00:07] scan | 0 routes, 0 models, 39 components → 4 articles
+
+## [2026-05-03 08:10:26] scan | 0 routes, 0 models, 39 components → 4 articles

--- a/.codesight/wiki/log.md
+++ b/.codesight/wiki/log.md
@@ -2,8 +2,6 @@
 
 History of `npx codesight --wiki` runs. Capped at 20 entries.
 
-## [2026-05-02 17:09:43] scan | 0 routes, 0 models, 39 components → 4 articles
-
 ## [2026-05-02 17:10:41] scan | 0 routes, 0 models, 39 components → 4 articles
 
 ## [2026-05-02 17:11:26] scan | 0 routes, 0 models, 39 components → 4 articles
@@ -41,3 +39,5 @@ History of `npx codesight --wiki` runs. Capped at 20 entries.
 ## [2026-05-03 07:15:21] scan | 0 routes, 0 models, 39 components → 4 articles
 
 ## [2026-05-03 07:17:32] scan | 0 routes, 0 models, 39 components → 4 articles
+
+## [2026-05-03 08:00:07] scan | 0 routes, 0 models, 39 components → 4 articles

--- a/.codesight/wiki/overview.md
+++ b/.codesight/wiki/overview.md
@@ -19,9 +19,9 @@ Changes to these files have the widest blast radius across the codebase:
 - `src\utils\theme.ts` — imported by **37** files
 - `src\store\useAppStore.ts` — imported by **33** files
 - `src\notifications\notificationManager.ts` — imported by **13** files
+- `src\detection\PermissionService.ts` — imported by **13** files
 - `src\storage\StorageService.ts` — imported by **11** files
 - `src\components\ResponsiveGridList.tsx` — imported by **11** files
-- `src\utils\helpers.ts` — imported by **10** files
 
 ## Required Environment Variables
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,15 +2,15 @@
 
 **Stack:** raw-http | none | typescript
 
-0 routes | 0 models | 3 env vars | 408 import links
+0 routes | 0 models | 3 env vars | 417 import links
 
 
 **High-impact files** (change carefully):
 - src\utils\theme.ts (imported by 37 files)
 - src\store\useAppStore.ts (imported by 33 files)
 - src\notifications\notificationManager.ts (imported by 13 files)
+- src\detection\PermissionService.ts (imported by 13 files)
 - src\storage\StorageService.ts (imported by 11 files)
-- src\components\ResponsiveGridList.tsx (imported by 11 files)
 
 **Required env vars:** EAS_BUILD_PROFILE, EXPO_PUBLIC_SHOW_DEV_MENU, NODE_ENV
 

--- a/src/__tests__/NotificationInfrastructureService.test.ts
+++ b/src/__tests__/NotificationInfrastructureService.test.ts
@@ -1,0 +1,93 @@
+import * as Notifications from 'expo-notifications';
+import { Platform } from 'react-native';
+import { NotificationInfrastructureService } from '../notifications/services/NotificationInfrastructureService';
+
+// Mock expo-notifications
+jest.mock('expo-notifications', () => ({
+  getPermissionsAsync: jest.fn(),
+  requestPermissionsAsync: jest.fn(),
+  setNotificationChannelAsync: jest.fn(),
+  setNotificationCategoryAsync: jest.fn(),
+  setNotificationHandler: jest.fn(),
+  addNotificationResponseReceivedListener: jest.fn(),
+  getLastNotificationResponseAsync: jest.fn(),
+  AndroidImportance: {
+    DEFAULT: 3,
+    MIN: 1,
+  },
+}));
+
+describe('NotificationInfrastructureService', () => {
+  let service: NotificationInfrastructureService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new NotificationInfrastructureService();
+    Platform.OS = 'android';
+  });
+
+  describe('requestNotificationPermissions', () => {
+    it('returns true immediately if permissions are already granted', async () => {
+      (Notifications.getPermissionsAsync as jest.Mock).mockResolvedValue({
+        status: 'granted',
+        canAskAgain: true,
+      });
+
+      const result = await service.requestNotificationPermissions();
+
+      expect(result.granted).toBe(true);
+      expect(Notifications.requestPermissionsAsync).not.toHaveBeenCalled();
+    });
+
+    it('requests permissions if not granted', async () => {
+      (Notifications.getPermissionsAsync as jest.Mock).mockResolvedValue({
+        status: 'denied',
+        canAskAgain: true,
+      });
+      (Notifications.requestPermissionsAsync as jest.Mock).mockResolvedValue({
+        status: 'granted',
+        canAskAgain: true,
+      });
+
+      const result = await service.requestNotificationPermissions();
+
+      expect(result.granted).toBe(true);
+      expect(Notifications.requestPermissionsAsync).toHaveBeenCalled();
+    });
+
+    it('returns false if request fails', async () => {
+      (Notifications.getPermissionsAsync as jest.Mock).mockResolvedValue({
+        status: 'denied',
+        canAskAgain: true,
+      });
+      (Notifications.requestPermissionsAsync as jest.Mock).mockResolvedValue({
+        status: 'denied',
+        canAskAgain: true,
+      });
+
+      const result = await service.requestNotificationPermissions();
+
+      expect(result.granted).toBe(false);
+    });
+
+    it('sets up channels and categories on successful grant (Android)', async () => {
+      Platform.OS = 'android';
+      (Notifications.getPermissionsAsync as jest.Mock).mockResolvedValue({
+        status: 'denied',
+        canAskAgain: true,
+      });
+      (Notifications.requestPermissionsAsync as jest.Mock).mockResolvedValue({
+        status: 'granted',
+        canAskAgain: true,
+      });
+
+      await service.requestNotificationPermissions();
+
+      expect(Notifications.setNotificationChannelAsync).toHaveBeenCalled();
+      expect(Notifications.setNotificationCategoryAsync).toHaveBeenCalledWith(
+        'reminder',
+        expect.any(Array)
+      );
+    });
+  });
+});

--- a/src/__tests__/PermissionService.test.ts
+++ b/src/__tests__/PermissionService.test.ts
@@ -1,0 +1,259 @@
+import * as Location from 'expo-location';
+import { PermissionsAndroid, Platform } from 'react-native';
+import { PermissionService } from '../detection/PermissionService';
+import * as healthConnect from 'react-native-health-connect';
+import * as healthIntent from '../detection/healthConnectIntent';
+
+// Unmock the service that was globally mocked in jest.setup.js
+jest.unmock('../detection/PermissionService');
+
+// Mock expo-location
+jest.mock('expo-location', () => ({
+  getForegroundPermissionsAsync: jest.fn(),
+  requestForegroundPermissionsAsync: jest.fn(),
+  getBackgroundPermissionsAsync: jest.fn(),
+  requestBackgroundPermissionsAsync: jest.fn(),
+}));
+
+// Mock react-native
+jest.mock('react-native', () => ({
+  Platform: {
+    OS: 'android',
+    Version: 30,
+  },
+  PermissionsAndroid: {
+    check: jest.fn(),
+    request: jest.fn(),
+    PERMISSIONS: {
+      ACTIVITY_RECOGNITION: 'android.permission.ACTIVITY_RECOGNITION',
+    },
+    RESULTS: {
+      GRANTED: 'granted',
+      DENIED: 'denied',
+      NEVER_ASK_AGAIN: 'never_ask_again',
+    },
+  },
+}));
+
+// Mock react-native-health-connect
+jest.mock('react-native-health-connect', () => ({
+  initialize: jest.fn(),
+  requestPermission: jest.fn(),
+}));
+
+// Mock healthConnectIntent
+jest.mock('../detection/healthConnectIntent', () => ({
+  openHealthConnectPermissionsViaIntent: jest.fn(),
+  verifyHealthConnectPermissions: jest.fn(),
+}));
+
+// Mock storage
+jest.mock('../storage', () => ({
+  setSettingAsync: jest.fn(),
+}));
+
+describe('PermissionService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default to Android
+    Platform.OS = 'android';
+    Platform.Version = 30;
+  });
+
+  describe('requestLocationPermissions', () => {
+    it('returns immediately if all permissions are already granted', async () => {
+      (Location.getForegroundPermissionsAsync as jest.Mock).mockResolvedValue({
+        status: 'granted',
+      });
+      (Location.getBackgroundPermissionsAsync as jest.Mock).mockResolvedValue({
+        status: 'granted',
+      });
+
+      const result = await PermissionService.requestLocationPermissions();
+
+      expect(result.granted).toBe(true);
+      expect(Location.requestForegroundPermissionsAsync).not.toHaveBeenCalled();
+      expect(Location.requestBackgroundPermissionsAsync).not.toHaveBeenCalled();
+    });
+
+    it('requests foreground if not granted, then background if foreground succeeds', async () => {
+      (Location.getForegroundPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'denied' });
+      (Location.requestForegroundPermissionsAsync as jest.Mock).mockResolvedValue({
+        status: 'granted',
+      });
+      (Location.getBackgroundPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'denied' });
+      (Location.requestBackgroundPermissionsAsync as jest.Mock).mockResolvedValue({
+        status: 'granted',
+      });
+
+      const result = await PermissionService.requestLocationPermissions();
+
+      expect(result.granted).toBe(true);
+      expect(Location.requestForegroundPermissionsAsync).toHaveBeenCalled();
+      expect(Location.requestBackgroundPermissionsAsync).toHaveBeenCalled();
+    });
+
+    it('stops if foreground request fails', async () => {
+      (Location.getForegroundPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'denied' });
+      (Location.requestForegroundPermissionsAsync as jest.Mock).mockResolvedValue({
+        status: 'denied',
+        canAskAgain: true,
+      });
+
+      const result = await PermissionService.requestLocationPermissions();
+
+      expect(result.granted).toBe(false);
+      expect(Location.requestBackgroundPermissionsAsync).not.toHaveBeenCalled();
+    });
+
+    it('returns false if background request fails', async () => {
+      (Location.getForegroundPermissionsAsync as jest.Mock).mockResolvedValue({
+        status: 'granted',
+      });
+      (Location.getBackgroundPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'denied' });
+      (Location.requestBackgroundPermissionsAsync as jest.Mock).mockResolvedValue({
+        status: 'denied',
+      });
+
+      const result = await PermissionService.requestLocationPermissions();
+
+      expect(result.granted).toBe(false);
+    });
+
+    it('catches and logs errors', async () => {
+      (Location.getForegroundPermissionsAsync as jest.Mock).mockRejectedValue(
+        new Error('Test error')
+      );
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+      const result = await PermissionService.requestLocationPermissions();
+
+      expect(result.granted).toBe(false);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Location permission request error'),
+        expect.any(Error)
+      );
+      consoleWarnSpy.mockRestore();
+    });
+  });
+
+  describe('requestWeatherLocationPermissions', () => {
+    it('returns true immediately if foreground is already granted', async () => {
+      (Location.getForegroundPermissionsAsync as jest.Mock).mockResolvedValue({
+        status: 'granted',
+      });
+
+      const result = await PermissionService.requestWeatherLocationPermissions();
+
+      expect(result).toBe(true);
+      expect(Location.requestForegroundPermissionsAsync).not.toHaveBeenCalled();
+    });
+
+    it('requests foreground if not granted', async () => {
+      (Location.getForegroundPermissionsAsync as jest.Mock).mockResolvedValue({ status: 'denied' });
+      (Location.requestForegroundPermissionsAsync as jest.Mock).mockResolvedValue({
+        status: 'granted',
+      });
+
+      const result = await PermissionService.requestWeatherLocationPermissions();
+
+      expect(result).toBe(true);
+      expect(Location.requestForegroundPermissionsAsync).toHaveBeenCalled();
+    });
+  });
+
+  describe('Activity Recognition', () => {
+    const ACTIVITY_RECOGNITION_PERMISSION = 'android.permission.ACTIVITY_RECOGNITION';
+
+    describe('checkActivityRecognitionPermissions', () => {
+      it('returns true on non-Android platforms', async () => {
+        jest.isolateModules(async () => {
+          const { Platform } = require('react-native');
+          Platform.OS = 'ios';
+          const { PermissionService } = require('../detection/PermissionService');
+          const result = await PermissionService.checkActivityRecognitionPermissions();
+          expect(result).toBe(true);
+        });
+      });
+
+      it('returns true on Android < 10 (API < 29)', async () => {
+        jest.isolateModules(async () => {
+          const { Platform } = require('react-native');
+          Platform.OS = 'android';
+          Platform.Version = 28;
+          const { PermissionService } = require('../detection/PermissionService');
+          const result = await PermissionService.checkActivityRecognitionPermissions();
+          expect(result).toBe(true);
+        });
+      });
+
+      it('checks permission on Android 10+', async () => {
+        jest.isolateModules(async () => {
+          const { Platform, PermissionsAndroid } = require('react-native');
+          Platform.OS = 'android';
+          Platform.Version = 29;
+          (PermissionsAndroid.check as jest.Mock).mockResolvedValue(true);
+
+          const { PermissionService } = require('../detection/PermissionService');
+          const result = await PermissionService.checkActivityRecognitionPermissions();
+
+          expect(result).toBe(true);
+          expect(PermissionsAndroid.check).toHaveBeenCalled();
+        });
+      });
+    });
+
+    describe('requestActivityRecognitionPermissions', () => {
+      it('returns granted immediately if already granted', async () => {
+        jest.isolateModules(async () => {
+          const { Platform, PermissionsAndroid } = require('react-native');
+          Platform.OS = 'android';
+          Platform.Version = 30;
+          (PermissionsAndroid.check as jest.Mock).mockResolvedValue(true);
+
+          const { PermissionService } = require('../detection/PermissionService');
+          const result = await PermissionService.requestActivityRecognitionPermissions();
+
+          expect(result.granted).toBe(true);
+          expect(PermissionsAndroid.request).not.toHaveBeenCalled();
+        });
+      });
+
+      it('requests permission if not granted', async () => {
+        jest.isolateModules(async () => {
+          const { Platform, PermissionsAndroid } = require('react-native');
+          Platform.OS = 'android';
+          Platform.Version = 30;
+          (PermissionsAndroid.check as jest.Mock).mockResolvedValue(false);
+          (PermissionsAndroid.request as jest.Mock).mockResolvedValue(
+            PermissionsAndroid.RESULTS.GRANTED
+          );
+
+          const { PermissionService } = require('../detection/PermissionService');
+          const result = await PermissionService.requestActivityRecognitionPermissions();
+
+          expect(result.granted).toBe(true);
+          expect(PermissionsAndroid.request).toHaveBeenCalled();
+        });
+      });
+
+      it('returns canAskAgain false if result is NEVER_ASK_AGAIN', async () => {
+        jest.isolateModules(async () => {
+          const { Platform, PermissionsAndroid } = require('react-native');
+          Platform.OS = 'android';
+          Platform.Version = 30;
+          (PermissionsAndroid.check as jest.Mock).mockResolvedValue(false);
+          (PermissionsAndroid.request as jest.Mock).mockResolvedValue(
+            PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN
+          );
+
+          const { PermissionService } = require('../detection/PermissionService');
+          const result = await PermissionService.requestActivityRecognitionPermissions();
+
+          expect(result.granted).toBe(false);
+          expect(result.canAskAgain).toBe(false);
+        });
+      });
+    });
+  });
+});

--- a/src/detection/PermissionService.ts
+++ b/src/detection/PermissionService.ts
@@ -1,6 +1,6 @@
 import * as Location from 'expo-location';
 import { initialize, requestPermission } from 'react-native-health-connect';
-import { PermissionsAndroid } from 'react-native';
+import { PermissionsAndroid, Permission, Platform } from 'react-native';
 import { setSettingAsync } from '../storage';
 import {
   openHealthConnectPermissionsViaIntent,
@@ -17,9 +17,23 @@ export class PermissionService {
     granted: boolean;
     canAskAgain: boolean;
   }> {
-    const { status: fg, canAskAgain: fgCanAsk } =
-      await Location.requestForegroundPermissionsAsync();
-    if (fg !== 'granted') return { granted: false, canAskAgain: fgCanAsk };
+    // 1. Check Foreground
+    const { status: currentFg } = await Location.getForegroundPermissionsAsync();
+
+    if (currentFg !== 'granted') {
+      const { status: fg, canAskAgain: fgCanAsk } =
+        await Location.requestForegroundPermissionsAsync();
+      if (fg !== 'granted') return { granted: false, canAskAgain: fgCanAsk };
+    }
+
+    // 2. Check Background
+    const { status: currentBg, canAskAgain: bgCanAskAgain } =
+      await Location.getBackgroundPermissionsAsync();
+    if (currentBg === 'granted') {
+      return { granted: true, canAskAgain: bgCanAskAgain };
+    }
+
+    // 3. Request Background (sequentially as required by Android 11+)
     const { status: bg, canAskAgain: bgCanAsk } =
       await Location.requestBackgroundPermissionsAsync();
     return { granted: bg === 'granted', canAskAgain: bgCanAsk };
@@ -84,6 +98,9 @@ export class PermissionService {
    */
   public static async requestWeatherLocationPermissions(): Promise<boolean> {
     try {
+      const { status: current } = await Location.getForegroundPermissionsAsync();
+      if (current === 'granted') return true;
+
       const { status } = await Location.requestForegroundPermissionsAsync();
       return status === 'granted';
     } catch (e) {
@@ -101,8 +118,16 @@ export class PermissionService {
   }
 
   public static async checkActivityRecognitionPermissions(): Promise<boolean> {
+    if (Platform.OS !== 'android') return true;
     try {
-      return await PermissionsAndroid.check(PermissionsAndroid.PERMISSIONS.ACTIVITY_RECOGNITION);
+      const apiLevel =
+        typeof Platform.Version === 'number' ? Platform.Version : parseInt(Platform.Version, 10);
+      if (apiLevel < 29) return true; // Granted at install time before Android 10
+
+      const permissionsMap = PermissionsAndroid.PERMISSIONS as Record<string, string>;
+      const perm = (permissionsMap.ACTIVITY_RECOGNITION ||
+        'android.permission.ACTIVITY_RECOGNITION') as Permission;
+      return await PermissionsAndroid.check(perm);
     } catch (e) {
       console.warn('Activity Recognition permission check error:', e);
       return false;
@@ -113,10 +138,21 @@ export class PermissionService {
     granted: boolean;
     canAskAgain: boolean;
   }> {
+    if (Platform.OS !== 'android') return { granted: true, canAskAgain: true };
+
     try {
-      const result = await PermissionsAndroid.request(
-        PermissionsAndroid.PERMISSIONS.ACTIVITY_RECOGNITION
-      );
+      const apiLevel =
+        typeof Platform.Version === 'number' ? Platform.Version : parseInt(Platform.Version, 10);
+      if (apiLevel < 29) return { granted: true, canAskAgain: true };
+
+      const permissionsMap = PermissionsAndroid.PERMISSIONS as Record<string, string>;
+      const perm = (permissionsMap.ACTIVITY_RECOGNITION ||
+        'android.permission.ACTIVITY_RECOGNITION') as Permission;
+
+      const isGranted = await PermissionsAndroid.check(perm);
+      if (isGranted) return { granted: true, canAskAgain: true };
+
+      const result = await PermissionsAndroid.request(perm);
       const granted = result === PermissionsAndroid.RESULTS.GRANTED;
       const canAskAgain = result !== PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN;
       return { granted, canAskAgain };

--- a/src/detection/PermissionService.ts
+++ b/src/detection/PermissionService.ts
@@ -9,6 +9,16 @@ import {
 
 const PERMISSION_WARNING_KEY = 'healthconnect_permission_warning';
 
+const ANDROID_API_LEVEL =
+  Platform.OS === 'android'
+    ? typeof Platform.Version === 'number'
+      ? Platform.Version
+      : parseInt(Platform.Version, 10)
+    : -1;
+
+const ACTIVITY_RECOGNITION_PERMISSION = ((PermissionsAndroid.PERMISSIONS as Record<string, string>)
+  .ACTIVITY_RECOGNITION || 'android.permission.ACTIVITY_RECOGNITION') as Permission;
+
 export class PermissionService {
   /**
    * Request location permissions (foreground + background).
@@ -17,26 +27,31 @@ export class PermissionService {
     granted: boolean;
     canAskAgain: boolean;
   }> {
-    // 1. Check Foreground
-    const { status: currentFg } = await Location.getForegroundPermissionsAsync();
+    try {
+      // 1. Check Foreground
+      const { status: currentFg } = await Location.getForegroundPermissionsAsync();
 
-    if (currentFg !== 'granted') {
-      const { status: fg, canAskAgain: fgCanAsk } =
-        await Location.requestForegroundPermissionsAsync();
-      if (fg !== 'granted') return { granted: false, canAskAgain: fgCanAsk };
+      if (currentFg !== 'granted') {
+        const { status: fg, canAskAgain: fgCanAsk } =
+          await Location.requestForegroundPermissionsAsync();
+        if (fg !== 'granted') return { granted: false, canAskAgain: fgCanAsk };
+      }
+
+      // 2. Check Background
+      const { status: currentBg, canAskAgain: bgCanAskAgain } =
+        await Location.getBackgroundPermissionsAsync();
+      if (currentBg === 'granted') {
+        return { granted: true, canAskAgain: bgCanAskAgain };
+      }
+
+      // 3. Request Background (sequentially as required by Android 11+)
+      const { status: bg, canAskAgain: bgCanAsk } =
+        await Location.requestBackgroundPermissionsAsync();
+      return { granted: bg === 'granted', canAskAgain: bgCanAsk };
+    } catch (e) {
+      console.warn('Location permission request error:', e);
+      return { granted: false, canAskAgain: true };
     }
-
-    // 2. Check Background
-    const { status: currentBg, canAskAgain: bgCanAskAgain } =
-      await Location.getBackgroundPermissionsAsync();
-    if (currentBg === 'granted') {
-      return { granted: true, canAskAgain: bgCanAskAgain };
-    }
-
-    // 3. Request Background (sequentially as required by Android 11+)
-    const { status: bg, canAskAgain: bgCanAsk } =
-      await Location.requestBackgroundPermissionsAsync();
-    return { granted: bg === 'granted', canAskAgain: bgCanAsk };
   }
 
   /**
@@ -120,14 +135,8 @@ export class PermissionService {
   public static async checkActivityRecognitionPermissions(): Promise<boolean> {
     if (Platform.OS !== 'android') return true;
     try {
-      const apiLevel =
-        typeof Platform.Version === 'number' ? Platform.Version : parseInt(Platform.Version, 10);
-      if (apiLevel < 29) return true; // Granted at install time before Android 10
-
-      const permissionsMap = PermissionsAndroid.PERMISSIONS as Record<string, string>;
-      const perm = (permissionsMap.ACTIVITY_RECOGNITION ||
-        'android.permission.ACTIVITY_RECOGNITION') as Permission;
-      return await PermissionsAndroid.check(perm);
+      if (ANDROID_API_LEVEL < 29) return true; // Granted at install time before Android 10
+      return await PermissionsAndroid.check(ACTIVITY_RECOGNITION_PERMISSION);
     } catch (e) {
       console.warn('Activity Recognition permission check error:', e);
       return false;
@@ -141,18 +150,12 @@ export class PermissionService {
     if (Platform.OS !== 'android') return { granted: true, canAskAgain: true };
 
     try {
-      const apiLevel =
-        typeof Platform.Version === 'number' ? Platform.Version : parseInt(Platform.Version, 10);
-      if (apiLevel < 29) return { granted: true, canAskAgain: true };
+      if (ANDROID_API_LEVEL < 29) return { granted: true, canAskAgain: true };
 
-      const permissionsMap = PermissionsAndroid.PERMISSIONS as Record<string, string>;
-      const perm = (permissionsMap.ACTIVITY_RECOGNITION ||
-        'android.permission.ACTIVITY_RECOGNITION') as Permission;
-
-      const isGranted = await PermissionsAndroid.check(perm);
+      const isGranted = await PermissionsAndroid.check(ACTIVITY_RECOGNITION_PERMISSION);
       if (isGranted) return { granted: true, canAskAgain: true };
 
-      const result = await PermissionsAndroid.request(perm);
+      const result = await PermissionsAndroid.request(ACTIVITY_RECOGNITION_PERMISSION);
       const granted = result === PermissionsAndroid.RESULTS.GRANTED;
       const canAskAgain = result !== PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN;
       return { granted, canAskAgain };

--- a/src/notifications/services/NotificationInfrastructureService.ts
+++ b/src/notifications/services/NotificationInfrastructureService.ts
@@ -152,6 +152,12 @@ export class NotificationInfrastructureService implements INotificationInfrastru
     granted: boolean;
     canAskAgain: boolean;
   }> {
+    const { status: currentStatus, canAskAgain: currentCanAsk } =
+      await Notifications.getPermissionsAsync();
+    if (currentStatus === 'granted') {
+      return { granted: true, canAskAgain: currentCanAsk };
+    }
+
     const { status, canAskAgain } = await Notifications.requestPermissionsAsync();
     if (status !== 'granted') {
       console.log('TouchGrass: Notification permissions not granted');


### PR DESCRIPTION
## Overview
This PR resolves issue #453 by stabilizing the Android permission request logic. It prevents "No requestable permission in the request" errors and potential `SecurityException` crashes by adding defensive guards and version-specific checks.

## Key Changes
- **PermissionService.ts**:
    - Added guards to check current status before requesting location and activity recognition permissions.
    - Added API level check (API 29+) for activity recognition.
    - Used a fallback string for `ACTIVITY_RECOGNITION` to handle potential missing constants in some RN environments.
- **NotificationInfrastructureService.ts**:
    - Added a guard to check current notification permission status before requesting.

## Verification
- `npm test`: Passed (854 tests).
- `npm run type-check`: Passed.
- `npm run lint`: Passed.