### PR TITLE
fix(notifications): resolve duplicate catchup reminders and stabilize eas runtime fingerprint

### DIFF
--- a/.codesight/CODESIGHT.md
+++ b/.codesight/CODESIGHT.md
@@ -4,7 +4,7 @@
 
 > 0 routes | 0 models | 39 components | 60 lib files | 3 env vars | 1 middleware | 0% test coverage
 > **Token savings:** this file is ~6.300 tokens. Without it, AI exploration would cost ~38.000 tokens. **Saves ~31.700 tokens per conversation.**
-> **Last scanned:** 2026-05-05 06:00 — re-run after significant changes
+> **Last scanned:** 2026-05-07 18:37 — re-run after significant changes
 
 ---
 

--- a/.codesight/CODESIGHT.md
+++ b/.codesight/CODESIGHT.md
@@ -4,7 +4,7 @@
 
 > 0 routes | 0 models | 39 components | 60 lib files | 3 env vars | 1 middleware | 0% test coverage
 > **Token savings:** this file is ~6.300 tokens. Without it, AI exploration would cost ~38.000 tokens. **Saves ~31.700 tokens per conversation.**
-> **Last scanned:** 2026-05-07 18:37 — re-run after significant changes
+> **Last scanned:** 2026-05-07 19:46 — re-run after significant changes
 
 ---
 

--- a/.codesight/CODESIGHT.md
+++ b/.codesight/CODESIGHT.md
@@ -4,7 +4,7 @@
 
 > 0 routes | 0 models | 39 components | 60 lib files | 3 env vars | 1 middleware | 0% test coverage
 > **Token savings:** this file is ~6.300 tokens. Without it, AI exploration would cost ~38.000 tokens. **Saves ~31.700 tokens per conversation.**
-> **Last scanned:** 2026-05-07 19:46 — re-run after significant changes
+> **Last scanned:** 2026-05-07 19:49 — re-run after significant changes
 
 ---
 

--- a/.codesight/wiki/index.md
+++ b/.codesight/wiki/index.md
@@ -1,6 +1,6 @@
 # touchgrass — Wiki
 
-_Generated 2026-05-05 — re-run `npx codesight --wiki` if the codebase has changed._
+_Generated 2026-05-07 — re-run `npx codesight --wiki` if the codebase has changed._
 
 Structural map compiled from source code via AST. No LLM — deterministic, 200ms.
 
@@ -45,4 +45,4 @@ When in doubt, search the source. The wiki is a starting point, not a complete i
 
 ---
 
-_Last compiled: 2026-05-05 · 4 articles · [codesight](https://github.com/Houseofmvps/codesight)_
+_Last compiled: 2026-05-07 · 4 articles · [codesight](https://github.com/Houseofmvps/codesight)_

--- a/.codesight/wiki/log.md
+++ b/.codesight/wiki/log.md
@@ -2,8 +2,6 @@
 
 History of `npx codesight --wiki` runs. Capped at 20 entries.
 
-## [2026-05-03 08:34:34] scan | 0 routes, 0 models, 39 components → 4 articles
-
 ## [2026-05-03 08:36:11] scan | 0 routes, 0 models, 39 components → 4 articles
 
 ## [2026-05-03 12:12:24] scan | 0 routes, 0 models, 39 components → 4 articles
@@ -41,3 +39,5 @@ History of `npx codesight --wiki` runs. Capped at 20 entries.
 ## [2026-05-05 06:00:04] scan | 0 routes, 0 models, 39 components → 4 articles
 
 ## [2026-05-07 18:37:22] scan | 0 routes, 0 models, 39 components → 4 articles
+
+## [2026-05-07 19:46:50] scan | 0 routes, 0 models, 39 components → 4 articles

--- a/.codesight/wiki/log.md
+++ b/.codesight/wiki/log.md
@@ -2,8 +2,6 @@
 
 History of `npx codesight --wiki` runs. Capped at 20 entries.
 
-## [2026-05-03 08:33:00] scan | 0 routes, 0 models, 39 components → 4 articles
-
 ## [2026-05-03 08:34:34] scan | 0 routes, 0 models, 39 components → 4 articles
 
 ## [2026-05-03 08:36:11] scan | 0 routes, 0 models, 39 components → 4 articles
@@ -41,3 +39,5 @@ History of `npx codesight --wiki` runs. Capped at 20 entries.
 ## [2026-05-05 05:56:57] scan | 0 routes, 0 models, 39 components → 4 articles
 
 ## [2026-05-05 06:00:04] scan | 0 routes, 0 models, 39 components → 4 articles
+
+## [2026-05-07 18:37:22] scan | 0 routes, 0 models, 39 components → 4 articles

--- a/.codesight/wiki/log.md
+++ b/.codesight/wiki/log.md
@@ -2,8 +2,6 @@
 
 History of `npx codesight --wiki` runs. Capped at 20 entries.
 
-## [2026-05-03 08:36:11] scan | 0 routes, 0 models, 39 components → 4 articles
-
 ## [2026-05-03 12:12:24] scan | 0 routes, 0 models, 39 components → 4 articles
 
 ## [2026-05-03 12:32:03] scan | 0 routes, 0 models, 39 components → 4 articles
@@ -41,3 +39,5 @@ History of `npx codesight --wiki` runs. Capped at 20 entries.
 ## [2026-05-07 18:37:22] scan | 0 routes, 0 models, 39 components → 4 articles
 
 ## [2026-05-07 19:46:50] scan | 0 routes, 0 models, 39 components → 4 articles
+
+## [2026-05-07 19:49:36] scan | 0 routes, 0 models, 39 components → 4 articles

--- a/.codesight/wiki/overview.md
+++ b/.codesight/wiki/overview.md
@@ -31,4 +31,4 @@ Changes to these files have the widest blast radius across the codebase:
 
 ---
 
-_Back to [index.md](./index.md) · Generated 2026-05-05_
+_Back to [index.md](./index.md) · Generated 2026-05-07_

--- a/.fingerprintignore
+++ b/.fingerprintignore
@@ -1,5 +1,7 @@
 # .fingerprintignore
-android/
-ios/
-node_modules/
-*.log
+# Uses minimatch patterns (NOT gitignore syntax)
+
+# These files can change for non-native reasons (e.g. adding coverage/ or .codesight/)
+# and should not affect the runtime version fingerprint.
+.gitignore
+.easignore

--- a/.github/workflows/beta-auto-deploy.yml
+++ b/.github/workflows/beta-auto-deploy.yml
@@ -22,22 +22,38 @@ jobs:
         with:
           fetch-depth: 0
       
-      - name: Check paths
+      - name: Check for Native Changes
         id: native_check
-        uses: dorny/paths-filter@v3
-        with:
-          # If it's a push, use the commit before the push. 
-          # If it's a manual run (workflow_dispatch), use main)
-          base: ${{ github.event_name == 'push' && github.event.before || 'main' }}
-          filters: |
-            native:
-              - 'package.json'
-              - 'app.json'
-              - 'app.config.js'
-              - 'ios/**'
-              - 'android/**'
-              - 'eas.json'
-              - 'withBackgroundFeaturesPlugin.js'
+        env:
+          EAS_BUILD_PROFILE: preview-emulator
+        run: |
+          BASE="${{ github.event_name == 'push' && github.event.before || 'main' }}"
+          # Safety check for force pushes or empty bases
+          if [[ "$BASE" =~ ^0+$ ]] || [ -z "$BASE" ]; then
+            BASE="main"
+          fi
+          echo "Comparing $BASE to HEAD..."
+          
+          # Generate current fingerprint hash
+          CURRENT_HASH=$(npx @expo/fingerprint . | jq -r '.hash')
+          echo "Current hash: $CURRENT_HASH"
+
+          # Checkout base commit and generate its fingerprint hash
+          git checkout --quiet $BASE
+          BASE_HASH=$(npx @expo/fingerprint . | jq -r '.hash')
+          echo "Base hash: $BASE_HASH"
+          
+          # Checkout back to the original commit
+          git checkout --quiet -
+
+          # Compare the two hashes
+          if [ "$CURRENT_HASH" != "$BASE_HASH" ]; then
+            echo "native=true" >> $GITHUB_OUTPUT
+            echo "🚨 Native changes detected in this push!"
+          else
+            echo "native=false" >> $GITHUB_OUTPUT
+            echo "✅ No native changes. Safe for OTA."
+          fi
 
   # 2. Run Semantic Versioning ONLY if native changes exist
   version-bump:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,52 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Check for Native Changes
+        id: native_check
+        env:
+          EAS_BUILD_PROFILE: development
+        run: |
+          if [ "${{ inputs.force_native_build }}" == "true" ]; then
+            echo "native=true" >> $GITHUB_OUTPUT
+            echo "🚨 Force Native Build selected via workflow_dispatch!"
+            exit 0
+          fi
+
+          # 1. Determine what we are comparing against
+          if [ "${{ github.event.action }}" == "synchronize" ]; then
+            BASE="${{ github.event.before }}"
+          else
+            BASE="${{ github.event.pull_request.base.sha }}"
+          fi
+          
+          # 2. Safety check: if BASE is all zeros (e.g. a force push) or empty (e.g. workflow_dispatch without PR), fallback gracefully
+          if [[ "$BASE" =~ ^0+$ ]] || [ -z "$BASE" ]; then
+            BASE="${{ github.event.pull_request.base.sha || github.event.before || github.sha }}"
+          fi
+          
+          echo "Comparing $BASE to HEAD..."
+          
+          # 3. Generate current fingerprint hash
+          CURRENT_HASH=$(npx @expo/fingerprint . | jq -r '.hash')
+          echo "Current hash: $CURRENT_HASH"
+
+          # 4. Checkout base commit and generate its fingerprint hash
+          git checkout --quiet $BASE
+          BASE_HASH=$(npx @expo/fingerprint . | jq -r '.hash')
+          echo "Base hash: $BASE_HASH"
+          
+          # 5. Checkout back to the original commit
+          git checkout --quiet -
+
+          # 6. Compare the two hashes
+          if [ "$CURRENT_HASH" != "$BASE_HASH" ]; then
+            echo "native=true" >> $GITHUB_OUTPUT
+            echo "🚨 Native changes detected in this push!"
+          else
+            echo "native=false" >> $GITHUB_OUTPUT
+            echo "✅ No native changes. Safe for OTA."
+          fi
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -60,37 +106,7 @@ jobs:
       - name: Run integration tests
         run: npx jest -c jest.integration.config.js
 
-      - name: Check for Native Changes
-        id: native_check
-        run: |
-          if [ "${{ inputs.force_native_build }}" == "true" ]; then
-            echo "native=true" >> $GITHUB_OUTPUT
-            echo "🚨 Force Native Build selected via workflow_dispatch!"
-            exit 0
-          fi
 
-          # 1. Determine what we are comparing against
-          if [ "${{ github.event.action }}" == "synchronize" ]; then
-            BASE="${{ github.event.before }}"
-          else
-            BASE="${{ github.event.pull_request.base.sha }}"
-          fi
-          
-          # 2. Safety check: if BASE is all zeros (e.g. a force push) or empty (e.g. workflow_dispatch without PR), fallback gracefully
-          if [[ "$BASE" =~ ^0+$ ]] || [ -z "$BASE" ]; then
-            BASE="${{ github.event.pull_request.base.sha || github.event.before || github.sha }}"
-          fi
-          
-          echo "Comparing $BASE to HEAD..."
-          
-          # 3. Use git diff to list changed files and grep for our native paths
-          if git diff --name-only $BASE ${{ github.sha }} | grep -qE '^package\.json$|^app\.json$|^app\.config\.js$|^ios/|^android/|^eas\.json$|^withBackgroundFeaturesPlugin\.js$'; then
-            echo "native=true" >> $GITHUB_OUTPUT
-            echo "🚨 Native changes detected in this push!"
-          else
-            echo "native=false" >> $GITHUB_OUTPUT
-            echo "✅ No native changes. Safe for OTA."
-          fi
 
       - name: ⚡️ Cache npx
         uses: actions/cache@v3

--- a/.github/workflows/production-auto-deploy.yml
+++ b/.github/workflows/production-auto-deploy.yml
@@ -18,20 +18,41 @@ jobs:
       native: ${{ steps.native_check.outputs.native }}
     steps:
       - uses: actions/checkout@v4
-
-      - name: Check paths
-        id: native_check
-        uses: dorny/paths-filter@v3
         with:
-          filters: |
-            native:
-              - 'package.json'
-              - 'app.json'
-              - 'app.config.js'
-              - 'ios/**'
-              - 'android/**'
-              - 'eas.json'
-              - 'withBackgroundFeaturesPlugin.js'
+          fetch-depth: 0
+
+      - name: Check for Native Changes
+        id: native_check
+        env:
+          EAS_BUILD_PROFILE: production
+        run: |
+          BASE="${{ github.event_name == 'push' && github.event.before || 'main' }}"
+          # Safety check for force pushes or empty bases
+          if [[ "$BASE" =~ ^0+$ ]] || [ -z "$BASE" ]; then
+            BASE="HEAD~1" # Fallback to previous commit for main branch force pushes
+          fi
+          echo "Comparing $BASE to HEAD..."
+          
+          # Generate current fingerprint hash
+          CURRENT_HASH=$(npx @expo/fingerprint . | jq -r '.hash')
+          echo "Current hash: $CURRENT_HASH"
+
+          # Checkout base commit and generate its fingerprint hash
+          git checkout --quiet $BASE
+          BASE_HASH=$(npx @expo/fingerprint . | jq -r '.hash')
+          echo "Base hash: $BASE_HASH"
+          
+          # Checkout back to the original commit
+          git checkout --quiet -
+
+          # Compare the two hashes
+          if [ "$CURRENT_HASH" != "$BASE_HASH" ]; then
+            echo "native=true" >> $GITHUB_OUTPUT
+            echo "🚨 Native changes detected in this push!"
+          else
+            echo "native=false" >> $GITHUB_OUTPUT
+            echo "✅ No native changes. Safe for OTA."
+          fi
 
   # 2. Run Semantic Versioning ONLY if native changes exist
   version-bump:

--- a/fingerprint.config.js
+++ b/fingerprint.config.js
@@ -1,6 +1,11 @@
 /** @type {import('@expo/fingerprint').Config} */
 module.exports = {
-  sourceSkips: ['ExpoConfigVersions'],
+  sourceSkips: [
+    'ExpoConfigVersions',
+    'GitIgnore',
+    'PackageJsonAndroidAndIosScriptsIfNotContainRun',
+  ],
+  ignorePaths: ['.easignore'],
   fileHookTransform: (source, chunk) => {
     if (!chunk) {
       return chunk;

--- a/src/__tests__/notificationManager.test.ts
+++ b/src/__tests__/notificationManager.test.ts
@@ -1385,6 +1385,74 @@ describe('notificationManager', () => {
         jest.useRealTimers();
         jest.restoreAllMocks();
       });
+
+      it('treats fired counts as 0 when tracked date is stale or value is invalid', async () => {
+        // Regression test for parsing robustness and stale date clearing
+        jest.useFakeTimers();
+        jest.setSystemTime(new Date('2026-03-14T10:05:00'));
+
+        const settingsStore: Record<string, string> = {
+          smart_reminder_queue: JSON.stringify([]),
+          smart_reminders_count: '1',
+          smart_catchup_reminders_count: '1',
+          sent_smart_reminders_date: 'Fri Mar 13 2026', // Stale date
+          sent_smart_reminders_count: '5', // Should be ignored due to stale date
+          sent_catchup_reminders_date: 'Sat Mar 14 2026', // Valid date
+          sent_catchup_reminders_count: 'NaN', // Invalid value, should fallback to 0
+        };
+        (Database.getTodayMinutesAsync as jest.Mock).mockResolvedValue(10);
+        (Database.getCurrentDailyGoalAsync as jest.Mock).mockResolvedValue({ targetMinutes: 30 });
+        (Database.getSettingAsync as jest.Mock).mockImplementation(
+          async (key: string, fallback: string) =>
+            key in settingsStore ? settingsStore[key] : fallback
+        );
+        (Database.setSettingAsync as jest.Mock).mockImplementation(
+          async (key: string, value: string) => {
+            settingsStore[key] = value;
+          }
+        );
+        (Notifications.getAllScheduledNotificationsAsync as jest.Mock).mockResolvedValue([]);
+        (ReminderAlgorithm.scoreReminderHours as jest.Mock).mockImplementation(
+          async (
+            _todayMins: number,
+            _target: number,
+            _h: number,
+            _m: number,
+            plannedSlots: any[],
+            baseDateMs: number
+          ) => {
+            const baseDate = new Date(baseDateMs);
+            const filterPlanned = (slots: any[]) =>
+              slots.filter(
+                (s) => !plannedSlots.some((p: any) => p.hour === s.hour && p.minute === s.minute)
+              );
+            if (baseDate.getDate() === 14) {
+              return filterPlanned([
+                { hour: 15, minute: 0, score: 0.75, reason: 'afternoon' },
+                { hour: 18, minute: 0, score: 0.8, reason: 'evening' },
+              ]);
+            }
+            return filterPlanned([{ hour: 9, minute: 0, score: 0.85, reason: 'tomorrow' }]);
+          }
+        );
+
+        await getSmartReminderScheduler().scheduleUpcomingReminders({ isHeadlessReplan: true });
+
+        const scheduledItems = (
+          SmartReminderModule.scheduleReminders as jest.Mock
+        ).mock.calls[0][0].filter((item: { type: string; timestamp: number }) => {
+          const d = new Date(item.timestamp);
+          return d.getDate() === 14 && item.type !== 'widget_reset';
+        });
+
+        // Smart reminder fired count was ignored (stale) = 0
+        // Catchup reminder fired count was ignored (NaN) = 0
+        // So scheduler needs 1 smart + 1 catchup = 2
+        expect(scheduledItems).toHaveLength(2);
+
+        jest.useRealTimers();
+        jest.restoreAllMocks();
+      });
     });
   });
 

--- a/src/__tests__/notificationManager.test.ts
+++ b/src/__tests__/notificationManager.test.ts
@@ -1227,6 +1227,164 @@ describe('notificationManager', () => {
         jest.useRealTimers();
         jest.restoreAllMocks();
       });
+      it('does not schedule extra smart reminders for today when fired count equals configured count', async () => {
+        // Regression: after 1 smart reminder fires (queue slot becomes consumed),
+        // the headless replan must NOT schedule a replacement for today.
+        jest.useFakeTimers();
+        jest.setSystemTime(new Date('2026-03-14T10:05:00')); // 5 min after 10:00 slot fired
+
+        const todayStr = 'Sat Mar 14 2026';
+        const settingsStore: Record<string, string> = {
+          // Queue: just-fired 10:00 slot is gone (consumed/removed); only tomorrow's slot remains
+          smart_reminder_queue: JSON.stringify([]),
+          smart_reminders_count: '1',
+          smart_catchup_reminders_count: '0',
+          // 1 smart reminder already fired today
+          sent_smart_reminders_date: todayStr,
+          sent_smart_reminders_count: '1',
+        };
+        (Database.getTodayMinutesAsync as jest.Mock).mockResolvedValue(10); // goal not met
+        (Database.getCurrentDailyGoalAsync as jest.Mock).mockResolvedValue({ targetMinutes: 30 });
+        (Database.getSettingAsync as jest.Mock).mockImplementation(
+          async (key: string, fallback: string) =>
+            key in settingsStore ? settingsStore[key] : fallback
+        );
+        (Database.setSettingAsync as jest.Mock).mockImplementation(
+          async (key: string, value: string) => {
+            settingsStore[key] = value;
+          }
+        );
+        (Notifications.getAllScheduledNotificationsAsync as jest.Mock).mockResolvedValue([]);
+        (ReminderAlgorithm.scoreReminderHours as jest.Mock).mockResolvedValue([
+          { hour: 9, minute: 0, score: 0.85, reason: 'tomorrow morning' },
+        ]);
+
+        await getSmartReminderScheduler().scheduleUpcomingReminders({ isHeadlessReplan: true });
+
+        const scheduledItems = (
+          SmartReminderModule.scheduleReminders as jest.Mock
+        ).mock.calls[0][0].filter((item: { type: string; timestamp: number }) => {
+          const d = new Date(item.timestamp);
+          return d.getDate() === 14 && item.type !== 'widget_reset';
+        });
+
+        // Must be 0: the 1 configured smart reminder already fired today
+        expect(scheduledItems).toHaveLength(0);
+
+        jest.useRealTimers();
+        jest.restoreAllMocks();
+      });
+
+      it('does not schedule extra catchup reminders for today when fired count equals configured count', async () => {
+        // Regression: 1 catchup already fired — scheduler must not plan another one.
+        jest.useFakeTimers();
+        jest.setSystemTime(new Date('2026-03-14T14:05:00'));
+
+        const todayStr = 'Sat Mar 14 2026';
+        const settingsStore: Record<string, string> = {
+          smart_reminder_queue: JSON.stringify([]),
+          smart_reminders_count: '1',
+          smart_catchup_reminders_count: '1',
+          sent_smart_reminders_date: todayStr,
+          sent_smart_reminders_count: '1',
+          sent_catchup_reminders_date: todayStr,
+          sent_catchup_reminders_count: '1', // 1 catchup already fired today
+        };
+        (Database.getTodayMinutesAsync as jest.Mock).mockResolvedValue(10);
+        (Database.getCurrentDailyGoalAsync as jest.Mock).mockResolvedValue({ targetMinutes: 30 });
+        (Database.getSettingAsync as jest.Mock).mockImplementation(
+          async (key: string, fallback: string) =>
+            key in settingsStore ? settingsStore[key] : fallback
+        );
+        (Database.setSettingAsync as jest.Mock).mockImplementation(
+          async (key: string, value: string) => {
+            settingsStore[key] = value;
+          }
+        );
+        (Notifications.getAllScheduledNotificationsAsync as jest.Mock).mockResolvedValue([]);
+        (ReminderAlgorithm.scoreReminderHours as jest.Mock).mockResolvedValue([
+          { hour: 9, minute: 0, score: 0.85, reason: 'tomorrow morning' },
+          { hour: 11, minute: 0, score: 0.7, reason: 'tomorrow noon' },
+        ]);
+
+        await getSmartReminderScheduler().scheduleUpcomingReminders({ isHeadlessReplan: true });
+
+        const scheduledItems = (
+          SmartReminderModule.scheduleReminders as jest.Mock
+        ).mock.calls[0][0].filter((item: { type: string; timestamp: number }) => {
+          const d = new Date(item.timestamp);
+          return d.getDate() === 14 && item.type !== 'widget_reset';
+        });
+
+        // Must be 0: both smart and catchup quotas are fulfilled for today
+        expect(scheduledItems).toHaveLength(0);
+
+        jest.useRealTimers();
+        jest.restoreAllMocks();
+      });
+
+      it('does schedule remaining reminders for today when fewer have fired than configured', async () => {
+        // Sanity: if 1 of 2 smart reminders fired, the planner must still schedule 1 more.
+        jest.useFakeTimers();
+        jest.setSystemTime(new Date('2026-03-14T10:05:00'));
+
+        const todayStr = 'Sat Mar 14 2026';
+        const settingsStore: Record<string, string> = {
+          smart_reminder_queue: JSON.stringify([]),
+          smart_reminders_count: '2', // 2 configured
+          smart_catchup_reminders_count: '0',
+          sent_smart_reminders_date: todayStr,
+          sent_smart_reminders_count: '1', // only 1 fired so far
+        };
+        (Database.getTodayMinutesAsync as jest.Mock).mockResolvedValue(10);
+        (Database.getCurrentDailyGoalAsync as jest.Mock).mockResolvedValue({ targetMinutes: 30 });
+        (Database.getSettingAsync as jest.Mock).mockImplementation(
+          async (key: string, fallback: string) =>
+            key in settingsStore ? settingsStore[key] : fallback
+        );
+        (Database.setSettingAsync as jest.Mock).mockImplementation(
+          async (key: string, value: string) => {
+            settingsStore[key] = value;
+          }
+        );
+        (Notifications.getAllScheduledNotificationsAsync as jest.Mock).mockResolvedValue([]);
+        (ReminderAlgorithm.scoreReminderHours as jest.Mock).mockImplementation(
+          async (
+            _todayMins: number,
+            _target: number,
+            _h: number,
+            _m: number,
+            plannedSlots: any[],
+            baseDateMs: number
+          ) => {
+            const baseDate = new Date(baseDateMs);
+            const filterPlanned = (slots: any[]) =>
+              slots.filter(
+                (s) => !plannedSlots.some((p: any) => p.hour === s.hour && p.minute === s.minute)
+              );
+            if (baseDate.getDate() === 14) {
+              return filterPlanned([{ hour: 15, minute: 0, score: 0.75, reason: 'afternoon' }]);
+            }
+            return filterPlanned([{ hour: 9, minute: 0, score: 0.85, reason: 'tomorrow' }]);
+          }
+        );
+
+        await getSmartReminderScheduler().scheduleUpcomingReminders({ isHeadlessReplan: true });
+
+        const scheduledItems = (
+          SmartReminderModule.scheduleReminders as jest.Mock
+        ).mock.calls[0][0].filter((item: { type: string; timestamp: number }) => {
+          const d = new Date(item.timestamp);
+          return d.getDate() === 14 && item.type !== 'widget_reset';
+        });
+
+        // 1 fired + 0 carried = 1, need 2 → must plan 1 more for today
+        expect(scheduledItems).toHaveLength(1);
+        expect(scheduledItems[0].type).toBe('smart_reminder');
+
+        jest.useRealTimers();
+        jest.restoreAllMocks();
+      });
     });
   });
 

--- a/src/__tests__/smartReminderTask.test.ts
+++ b/src/__tests__/smartReminderTask.test.ts
@@ -196,6 +196,67 @@ describe('handleSmartReminder', () => {
     expect(mockScheduler.scheduleUpcomingReminders).toHaveBeenCalled();
   });
 
+  it('should increment sent_catchup_reminders_count when catchup reminder is sent', async () => {
+    (getTodayMinutesAsync as jest.Mock).mockResolvedValue(10);
+    (getCurrentDailyGoalAsync as jest.Mock).mockResolvedValue({ targetMinutes: 30 });
+
+    const todayStr = new Date().toDateString();
+    const settingsStore: Record<string, string> = {
+      sent_smart_reminders_date: todayStr,
+      sent_smart_reminders_count: '1', // 1 smart already fired
+      sent_catchup_reminders_date: todayStr,
+      sent_catchup_reminders_count: '0', // no catchup fired yet
+      smart_reminders_count: '2',
+    };
+    mockStorage.getSettingAsync.mockImplementation((key: string, fallback: string) =>
+      key in settingsStore ? settingsStore[key] : fallback
+    );
+    mockStorage.setSettingAsync.mockImplementation((key: string, value: string) => {
+      settingsStore[key] = value;
+    });
+
+    // progressRatio = 10/30 ≈ 0.33, expectedRatio = 1/2 = 0.50 → catchup fires
+    await handleSmartReminder({ type: 'catchup_reminder' });
+
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalled();
+    expect(mockStorage.setSettingAsync).toHaveBeenCalledWith(
+      'sent_catchup_reminders_date',
+      todayStr
+    );
+    expect(mockStorage.setSettingAsync).toHaveBeenCalledWith('sent_catchup_reminders_count', '1');
+  });
+
+  it('should treat sent_catchup_reminders_count as 0 when tracked date is a different day', async () => {
+    (getTodayMinutesAsync as jest.Mock).mockResolvedValue(10);
+    (getCurrentDailyGoalAsync as jest.Mock).mockResolvedValue({ targetMinutes: 30 });
+
+    const todayStr = new Date().toDateString();
+    const settingsStore: Record<string, string> = {
+      sent_smart_reminders_date: todayStr,
+      sent_smart_reminders_count: '1',
+      sent_catchup_reminders_date: 'Mon Jan 01 2000', // stale date from a previous day
+      sent_catchup_reminders_count: '99', // stale count — must be ignored
+      smart_reminders_count: '2',
+    };
+    mockStorage.getSettingAsync.mockImplementation((key: string, fallback: string) =>
+      key in settingsStore ? settingsStore[key] : fallback
+    );
+    mockStorage.setSettingAsync.mockImplementation((key: string, value: string) => {
+      settingsStore[key] = value;
+    });
+
+    // progressRatio = 10/30 ≈ 0.33, expectedRatio = 1/2 = 0.50 → catchup fires
+    await handleSmartReminder({ type: 'catchup_reminder' });
+
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalled();
+    // Counter must start fresh from 1, not 100
+    expect(mockStorage.setSettingAsync).toHaveBeenCalledWith('sent_catchup_reminders_count', '1');
+    expect(mockStorage.setSettingAsync).toHaveBeenCalledWith(
+      'sent_catchup_reminders_date',
+      todayStr
+    );
+  });
+
   it('should execute finally block even if fetchWeatherForecast throws', async () => {
     (fetchWeatherForecast as jest.Mock).mockRejectedValue(new Error('Weather failed'));
 

--- a/src/background/smartReminderTask.ts
+++ b/src/background/smartReminderTask.ts
@@ -64,9 +64,11 @@ export const handleSmartReminder = async (data: HeadlessData) => {
       sentSmartReminders = 0;
     }
 
-    const lastCatchupDate = await storageService.getSettingAsync('sent_catchup_reminders_date', '');
-    let sentCatchupReminders =
-      parseInt(await storageService.getSettingAsync('sent_catchup_reminders_count', '0'), 10) || 0;
+    const [lastCatchupDate, catchupCountStr] = await Promise.all([
+      storageService.getSettingAsync('sent_catchup_reminders_date', ''),
+      storageService.getSettingAsync('sent_catchup_reminders_count', '0'),
+    ]);
+    let sentCatchupReminders = parseInt(catchupCountStr, 10) || 0;
 
     if (lastCatchupDate !== todayDateStr) {
       sentCatchupReminders = 0;
@@ -198,11 +200,17 @@ export const handleSmartReminder = async (data: HeadlessData) => {
         );
         // Increment catchup fired counter before sending
         sentCatchupReminders += 1;
-        await storageService.setSettingAsync('sent_catchup_reminders_date', todayDateStr);
-        await storageService.setSettingAsync(
-          'sent_catchup_reminders_count',
-          sentCatchupReminders.toString()
-        );
+        try {
+          await Promise.all([
+            storageService.setSettingAsync('sent_catchup_reminders_date', todayDateStr),
+            storageService.setSettingAsync(
+              'sent_catchup_reminders_count',
+              sentCatchupReminders.toString()
+            ),
+          ]);
+        } catch (error) {
+          console.warn('[SR_HEADLESS] Non-critical storage failure saving catchup count', error);
+        }
         shouldSend = true;
       } else {
         console.log(

--- a/src/background/smartReminderTask.ts
+++ b/src/background/smartReminderTask.ts
@@ -64,6 +64,14 @@ export const handleSmartReminder = async (data: HeadlessData) => {
       sentSmartReminders = 0;
     }
 
+    const lastCatchupDate = await storageService.getSettingAsync('sent_catchup_reminders_date', '');
+    let sentCatchupReminders =
+      parseInt(await storageService.getSettingAsync('sent_catchup_reminders_count', '0'), 10) || 0;
+
+    if (lastCatchupDate !== todayDateStr) {
+      sentCatchupReminders = 0;
+    }
+
     const smartRemindersCount =
       parseInt(await storageService.getSettingAsync('smart_reminders_count', '2'), 10) || 2;
 
@@ -187,6 +195,13 @@ export const handleSmartReminder = async (data: HeadlessData) => {
       if (progressRatio <= expectedRatio && todayMinutes < targetMinutes) {
         console.log(
           `[SR_HEADLESS] Catchup triggered: activity progress (${progressRatio.toFixed(2)}) <= notification progress (${expectedRatio.toFixed(2)})`
+        );
+        // Increment catchup fired counter before sending
+        sentCatchupReminders += 1;
+        await storageService.setSettingAsync('sent_catchup_reminders_date', todayDateStr);
+        await storageService.setSettingAsync(
+          'sent_catchup_reminders_count',
+          sentCatchupReminders.toString()
         );
         shouldSend = true;
       } else {

--- a/src/notifications/services/SmartReminderScheduler.ts
+++ b/src/notifications/services/SmartReminderScheduler.ts
@@ -365,7 +365,41 @@ export class SmartReminderScheduler implements ISmartReminderScheduler {
           10
         );
 
-        if (carriedSmartCount < remindersCount || carriedCatchupCount < catchupLimit) {
+        // Account for reminders that already fired today (tracked by the headless task).
+        // This prevents the replanner from treating a just-fired slot as an unfilled gap
+        // and scheduling an extra reminder to compensate.
+        // Note: the headless task stores this date via new Date().toDateString() (e.g. "Sat Mar 14 2026"),
+        // so we compare using the same format here.
+        const todayDateStr = now.toDateString();
+        const lastFiredSmartDate = await this.storageService.getSettingAsync(
+          'sent_smart_reminders_date',
+          ''
+        );
+        const firedSmartToday =
+          lastFiredSmartDate === todayDateStr
+            ? parseInt(
+                await this.storageService.getSettingAsync('sent_smart_reminders_count', '0'),
+                10
+              ) || 0
+            : 0;
+
+        const lastFiredCatchupDate = await this.storageService.getSettingAsync(
+          'sent_catchup_reminders_date',
+          ''
+        );
+        const firedCatchupToday =
+          lastFiredCatchupDate === todayDateStr
+            ? parseInt(
+                await this.storageService.getSettingAsync('sent_catchup_reminders_count', '0'),
+                10
+              ) || 0
+            : 0;
+
+        // Effective count = future slots still in queue + already-fired today
+        const effectiveSmartCount = carriedSmartCount + firedSmartToday;
+        const effectiveCatchupCount = carriedCatchupCount + firedCatchupToday;
+
+        if (effectiveSmartCount < remindersCount || effectiveCatchupCount < catchupLimit) {
           const todaySlots = await this.planDaySlots(
             now,
             todayMinutes,

--- a/src/notifications/services/SmartReminderScheduler.ts
+++ b/src/notifications/services/SmartReminderScheduler.ts
@@ -371,29 +371,19 @@ export class SmartReminderScheduler implements ISmartReminderScheduler {
         // Note: the headless task stores this date via new Date().toDateString() (e.g. "Sat Mar 14 2026"),
         // so we compare using the same format here.
         const todayDateStr = now.toDateString();
-        const lastFiredSmartDate = await this.storageService.getSettingAsync(
-          'sent_smart_reminders_date',
-          ''
-        );
-        const firedSmartToday =
-          lastFiredSmartDate === todayDateStr
-            ? parseInt(
-                await this.storageService.getSettingAsync('sent_smart_reminders_count', '0'),
-                10
-              ) || 0
-            : 0;
+        const [lastFiredSmartDate, lastFiredCatchupDate, firedSmartCountStr, firedCatchupCountStr] =
+          await Promise.all([
+            this.storageService.getSettingAsync('sent_smart_reminders_date', ''),
+            this.storageService.getSettingAsync('sent_catchup_reminders_date', ''),
+            this.storageService.getSettingAsync('sent_smart_reminders_count', '0'),
+            this.storageService.getSettingAsync('sent_catchup_reminders_count', '0'),
+          ]);
 
-        const lastFiredCatchupDate = await this.storageService.getSettingAsync(
-          'sent_catchup_reminders_date',
-          ''
-        );
+        const firedSmartToday =
+          lastFiredSmartDate === todayDateStr ? parseInt(firedSmartCountStr, 10) || 0 : 0;
+
         const firedCatchupToday =
-          lastFiredCatchupDate === todayDateStr
-            ? parseInt(
-                await this.storageService.getSettingAsync('sent_catchup_reminders_count', '0'),
-                10
-              ) || 0
-            : 0;
+          lastFiredCatchupDate === todayDateStr ? parseInt(firedCatchupCountStr, 10) || 0 : 0;
 
         // Effective count = future slots still in queue + already-fired today
         const effectiveSmartCount = carriedSmartCount + firedSmartToday;


### PR DESCRIPTION
This PR addresses two significant stability bugs before our upcoming beta release:

### 1. Duplicate Catchup Reminders (Headless Replanner Bug)
The headless task was failing to recognize "consumed" reminders when checking for missed capacity. This caused the algorithm to erroneously generate additional catchup reminders because it treated already-fired slots as unfilled gaps.
*   **Fix**: Implemented a durable counter (`sent_catchup_reminders_count`) that tracks the number of catchup reminders actually sent today. This fired count is now injected into the scheduler's effective capacity calculation, preventing it from exceeding daily limits.
*   **Testing**: Added full test coverage ensuring redundant catchups are blocked when the quota is reached.

### 2. Unstable EAS Runtime Versions
The `runtimeVersion` was changing across commits that had zero native modifications, triggering unnecessary native rebuilds.
*   **Root Cause**: `@expo/fingerprint` was hashing `.gitignore` changes (e.g. adding `coverage/`), and tracking `.easignore`. Additionally, an earlier `fingerprint.config.js` accidentally disabled default exclusions (like omitting the `version` field from `package.json` and skipping scripts).
*   **Fix**: Corrected the minimatch patterns in `.fingerprintignore` to effectively filter out `.gitignore` and `.easignore`. Re-configured `fingerprint.config.js` to ensure the correct defaults (`ExpoConfigVersions`, `GitIgnore`, `PackageJsonAndroidAndIosScriptsIfNotContainRun`) remain active alongside the existing `package.json` fileHook transforms.
*   **Verification**: Ran `fingerprint:diff` before and after these changes across multiple commits, proving the diff evaluates to `[]` as intended.