### PR TITLE
feat: Add 1.8.0 migration tutorial screen

### DIFF
--- a/.codesight/CODESIGHT.md
+++ b/.codesight/CODESIGHT.md
@@ -4,7 +4,7 @@
 
 > 0 routes | 0 models | 40 components | 59 lib files | 3 env vars | 1 middleware | 0% test coverage
 > **Token savings:** this file is ~6.300 tokens. Without it, AI exploration would cost ~38.100 tokens. **Saves ~31.800 tokens per conversation.**
-> **Last scanned:** 2026-05-08 05:59 — re-run after significant changes
+> **Last scanned:** 2026-05-08 06:54 — re-run after significant changes
 
 ---
 

--- a/.codesight/CODESIGHT.md
+++ b/.codesight/CODESIGHT.md
@@ -4,7 +4,7 @@
 
 > 0 routes | 0 models | 40 components | 59 lib files | 3 env vars | 1 middleware | 0% test coverage
 > **Token savings:** this file is ~6.300 tokens. Without it, AI exploration would cost ~38.100 tokens. **Saves ~31.800 tokens per conversation.**
-> **Last scanned:** 2026-05-08 06:54 — re-run after significant changes
+> **Last scanned:** 2026-05-08 06:59 — re-run after significant changes
 
 ---
 

--- a/.codesight/CODESIGHT.md
+++ b/.codesight/CODESIGHT.md
@@ -2,9 +2,9 @@
 
 > **Stack:** raw-http | none | react | typescript
 
-> 0 routes | 0 models | 39 components | 59 lib files | 3 env vars | 1 middleware | 0% test coverage
-> **Token savings:** this file is ~6.300 tokens. Without it, AI exploration would cost ~37.800 tokens. **Saves ~31.500 tokens per conversation.**
-> **Last scanned:** 2026-05-08 05:52 — re-run after significant changes
+> 0 routes | 0 models | 40 components | 59 lib files | 3 env vars | 1 middleware | 0% test coverage
+> **Token savings:** this file is ~6.300 tokens. Without it, AI exploration would cost ~38.100 tokens. **Saves ~31.800 tokens per conversation.**
+> **Last scanned:** 2026-05-08 05:59 — re-run after significant changes
 
 ---
 
@@ -44,6 +44,7 @@
 - **HomeScreen** — `src\screens\HomeScreen.tsx`
 - **IntroScreen** — props: onComplete — `src\screens\IntroScreen.tsx`
 - **KnownLocationsScreen** — `src\screens\KnownLocationsScreen.tsx`
+- **Migration180Screen** — props: onComplete — `src\screens\Migration180Screen.tsx`
 - **ScheduledNotificationsScreen** — `src\screens\ScheduledNotificationsScreen.tsx`
 - **SettingsScreen** — `src\screens\SettingsScreen.tsx`
 - **WeatherSettingsScreen** — `src\screens\WeatherSettingsScreen.tsx`
@@ -318,18 +319,18 @@
 
 ## Most Imported Files (change these carefully)
 
-- `src\utils\theme.ts` — imported by **39** files
-- `src\store\useAppStore.ts` — imported by **33** files
+- `src\utils\theme.ts` — imported by **40** files
+- `src\store\useAppStore.ts` — imported by **34** files
 - `src\notifications\notificationManager.ts` — imported by **15** files
-- `src\detection\PermissionService.ts` — imported by **13** files
+- `src\detection\PermissionService.ts` — imported by **14** files
 - `src\storage\StorageService.ts` — imported by **11** files
 - `src\components\ResponsiveGridList.tsx` — imported by **11** files
 - `src\utils\helpers.ts` — imported by **10** files
 - `src\storage\types.ts` — imported by **10** files
 - `src\storage\db.ts` — imported by **10** files
+- `src\detection\index.ts` — imported by **9** files
 - `src\utils\widgetHelper.ts` — imported by **9** files
 - `src\utils\sessionsChangedEmitter.ts` — imported by **9** files
-- `src\detection\index.ts` — imported by **8** files
 - `src\detection\sessionMerger.ts` — imported by **8** files
 - `src\detection\manualCheckin.ts` — imported by **8** files
 - `src\i18n\en.ts` — imported by **8** files
@@ -341,16 +342,16 @@
 
 ## Import Map (who imports what)
 
-- `src\utils\theme.ts` ← `src\background\smartReminderTask.ts`, `src\components\DiagnosticSheet.tsx`, `src\components\EditLocationSheet.tsx`, `src\components\EditSessionSheet.tsx`, `src\components\ErrorBoundary.tsx` +34 more
-- `src\store\useAppStore.ts` ← `App.tsx`, `src\components\DiagnosticSheet.tsx`, `src\components\EditLocationSheet.tsx`, `src\components\EditSessionSheet.tsx`, `src\components\ErrorBoundary.tsx` +28 more
+- `src\utils\theme.ts` ← `src\background\smartReminderTask.ts`, `src\components\DiagnosticSheet.tsx`, `src\components\EditLocationSheet.tsx`, `src\components\EditSessionSheet.tsx`, `src\components\ErrorBoundary.tsx` +35 more
+- `src\store\useAppStore.ts` ← `App.tsx`, `src\components\DiagnosticSheet.tsx`, `src\components\EditLocationSheet.tsx`, `src\components\EditSessionSheet.tsx`, `src\components\ErrorBoundary.tsx` +29 more
 - `src\notifications\notificationManager.ts` ← `src\background\geofenceTask.ts`, `src\components\EditLocationSheet.tsx`, `src\hooks\useForegroundSync.ts`, `src\hooks\useGoalIntegrations.ts`, `src\notifications\services\ReminderQueueManager.ts` +10 more
-- `src\detection\PermissionService.ts` ← `src\detection\gpsDetection.ts`, `src\detection\healthConnect.ts`, `src\detection\index.ts`, `src\hooks\useDetectionSettings.ts`, `src\screens\IntroScreen.tsx` +8 more
+- `src\detection\PermissionService.ts` ← `src\detection\gpsDetection.ts`, `src\detection\healthConnect.ts`, `src\detection\index.ts`, `src\hooks\useDetectionSettings.ts`, `src\screens\IntroScreen.tsx` +9 more
 - `src\storage\StorageService.ts` ← `src\background\smartReminderTask.ts`, `src\core\container.ts`, `src\notifications\services\NotificationResponseHandler.ts`, `src\notifications\services\ReminderMessageBuilder.ts`, `src\notifications\services\ReminderQueueManager.ts` +6 more
 - `src\components\ResponsiveGridList.tsx` ← `src\screens\AboutAppScreen.tsx`, `src\screens\ActivityLogScreen.tsx`, `src\screens\EventsScreen.tsx`, `src\screens\FeedbackSupportScreen.tsx`, `src\screens\GoalsScreen.tsx` +6 more
 - `src\utils\helpers.ts` ← `src\components\EditSessionSheet.tsx`, `src\components\ManualSessionSheet.tsx`, `src\components\ProgressRing.tsx`, `src\components\ReminderFeedbackModal.tsx`, `src\i18n\index.ts` +5 more
 - `src\storage\types.ts` ← `src\domain\SessionDomain.ts`, `src\storage\index.ts`, `src\storage\repositories\GoalRepository.ts`, `src\storage\repositories\LocationRepository.ts`, `src\storage\repositories\LogRepository.ts` +5 more
 - `src\storage\db.ts` ← `src\storage\index.ts`, `src\storage\repositories\GoalRepository.ts`, `src\storage\repositories\LocationRepository.ts`, `src\storage\repositories\LogRepository.ts`, `src\storage\repositories\NotificationRepository.ts` +5 more
-- `src\utils\widgetHelper.ts` ← `appBootstrap.ts`, `src\background\smartReminderTask.ts`, `src\hooks\useForegroundSync.ts`, `src\screens\EventsScreen.tsx`, `src\widget\widget-task-handler.tsx` +4 more
+- `src\detection\index.ts` ← `appBootstrap.ts`, `src\screens\HealthConnectRationaleScreen.tsx`, `src\screens\KnownLocationsScreen.tsx`, `src\screens\Migration180Screen.tsx`, `src\__tests__\detectionBackgroundTask.test.ts` +4 more
 
 ---
 

--- a/.codesight/components.md
+++ b/.codesight/components.md
@@ -34,6 +34,7 @@
 - **HomeScreen** — `src\screens\HomeScreen.tsx`
 - **IntroScreen** — props: onComplete — `src\screens\IntroScreen.tsx`
 - **KnownLocationsScreen** — `src\screens\KnownLocationsScreen.tsx`
+- **Migration180Screen** — props: onComplete — `src\screens\Migration180Screen.tsx`
 - **ScheduledNotificationsScreen** — `src\screens\ScheduledNotificationsScreen.tsx`
 - **SettingsScreen** — `src\screens\SettingsScreen.tsx`
 - **WeatherSettingsScreen** — `src\screens\WeatherSettingsScreen.tsx`

--- a/.codesight/graph.md
+++ b/.codesight/graph.md
@@ -2,18 +2,18 @@
 
 ## Most Imported Files (change these carefully)
 
-- `src\utils\theme.ts` — imported by **39** files
-- `src\store\useAppStore.ts` — imported by **33** files
+- `src\utils\theme.ts` — imported by **40** files
+- `src\store\useAppStore.ts` — imported by **34** files
 - `src\notifications\notificationManager.ts` — imported by **15** files
-- `src\detection\PermissionService.ts` — imported by **13** files
+- `src\detection\PermissionService.ts` — imported by **14** files
 - `src\storage\StorageService.ts` — imported by **11** files
 - `src\components\ResponsiveGridList.tsx` — imported by **11** files
 - `src\utils\helpers.ts` — imported by **10** files
 - `src\storage\types.ts` — imported by **10** files
 - `src\storage\db.ts` — imported by **10** files
+- `src\detection\index.ts` — imported by **9** files
 - `src\utils\widgetHelper.ts` — imported by **9** files
 - `src\utils\sessionsChangedEmitter.ts` — imported by **9** files
-- `src\detection\index.ts` — imported by **8** files
 - `src\detection\sessionMerger.ts` — imported by **8** files
 - `src\detection\manualCheckin.ts` — imported by **8** files
 - `src\i18n\en.ts` — imported by **8** files
@@ -25,13 +25,13 @@
 
 ## Import Map (who imports what)
 
-- `src\utils\theme.ts` ← `src\background\smartReminderTask.ts`, `src\components\DiagnosticSheet.tsx`, `src\components\EditLocationSheet.tsx`, `src\components\EditSessionSheet.tsx`, `src\components\ErrorBoundary.tsx` +34 more
-- `src\store\useAppStore.ts` ← `App.tsx`, `src\components\DiagnosticSheet.tsx`, `src\components\EditLocationSheet.tsx`, `src\components\EditSessionSheet.tsx`, `src\components\ErrorBoundary.tsx` +28 more
+- `src\utils\theme.ts` ← `src\background\smartReminderTask.ts`, `src\components\DiagnosticSheet.tsx`, `src\components\EditLocationSheet.tsx`, `src\components\EditSessionSheet.tsx`, `src\components\ErrorBoundary.tsx` +35 more
+- `src\store\useAppStore.ts` ← `App.tsx`, `src\components\DiagnosticSheet.tsx`, `src\components\EditLocationSheet.tsx`, `src\components\EditSessionSheet.tsx`, `src\components\ErrorBoundary.tsx` +29 more
 - `src\notifications\notificationManager.ts` ← `src\background\geofenceTask.ts`, `src\components\EditLocationSheet.tsx`, `src\hooks\useForegroundSync.ts`, `src\hooks\useGoalIntegrations.ts`, `src\notifications\services\ReminderQueueManager.ts` +10 more
-- `src\detection\PermissionService.ts` ← `src\detection\gpsDetection.ts`, `src\detection\healthConnect.ts`, `src\detection\index.ts`, `src\hooks\useDetectionSettings.ts`, `src\screens\IntroScreen.tsx` +8 more
+- `src\detection\PermissionService.ts` ← `src\detection\gpsDetection.ts`, `src\detection\healthConnect.ts`, `src\detection\index.ts`, `src\hooks\useDetectionSettings.ts`, `src\screens\IntroScreen.tsx` +9 more
 - `src\storage\StorageService.ts` ← `src\background\smartReminderTask.ts`, `src\core\container.ts`, `src\notifications\services\NotificationResponseHandler.ts`, `src\notifications\services\ReminderMessageBuilder.ts`, `src\notifications\services\ReminderQueueManager.ts` +6 more
 - `src\components\ResponsiveGridList.tsx` ← `src\screens\AboutAppScreen.tsx`, `src\screens\ActivityLogScreen.tsx`, `src\screens\EventsScreen.tsx`, `src\screens\FeedbackSupportScreen.tsx`, `src\screens\GoalsScreen.tsx` +6 more
 - `src\utils\helpers.ts` ← `src\components\EditSessionSheet.tsx`, `src\components\ManualSessionSheet.tsx`, `src\components\ProgressRing.tsx`, `src\components\ReminderFeedbackModal.tsx`, `src\i18n\index.ts` +5 more
 - `src\storage\types.ts` ← `src\domain\SessionDomain.ts`, `src\storage\index.ts`, `src\storage\repositories\GoalRepository.ts`, `src\storage\repositories\LocationRepository.ts`, `src\storage\repositories\LogRepository.ts` +5 more
 - `src\storage\db.ts` ← `src\storage\index.ts`, `src\storage\repositories\GoalRepository.ts`, `src\storage\repositories\LocationRepository.ts`, `src\storage\repositories\LogRepository.ts`, `src\storage\repositories\NotificationRepository.ts` +5 more
-- `src\utils\widgetHelper.ts` ← `appBootstrap.ts`, `src\background\smartReminderTask.ts`, `src\hooks\useForegroundSync.ts`, `src\screens\EventsScreen.tsx`, `src\widget\widget-task-handler.tsx` +4 more
+- `src\detection\index.ts` ← `appBootstrap.ts`, `src\screens\HealthConnectRationaleScreen.tsx`, `src\screens\KnownLocationsScreen.tsx`, `src\screens\Migration180Screen.tsx`, `src\__tests__\detectionBackgroundTask.test.ts` +4 more

--- a/.codesight/wiki/index.md
+++ b/.codesight/wiki/index.md
@@ -16,7 +16,7 @@ Structural map compiled from source code via AST. No LLM — deterministic, 200m
 
 - Routes: **0**
 - Models: **0**
-- Components: **39**
+- Components: **40**
 - Env vars: **3** required, **0** with defaults
 
 ## How to Use

--- a/.codesight/wiki/log.md
+++ b/.codesight/wiki/log.md
@@ -2,8 +2,6 @@
 
 History of `npx codesight --wiki` runs. Capped at 20 entries.
 
-## [2026-05-04 11:14:23] scan | 0 routes, 0 models, 39 components → 4 articles
-
 ## [2026-05-04 11:14:52] scan | 0 routes, 0 models, 39 components → 4 articles
 
 ## [2026-05-04 12:37:01] scan | 0 routes, 0 models, 39 components → 4 articles
@@ -41,3 +39,5 @@ History of `npx codesight --wiki` runs. Capped at 20 entries.
 ## [2026-05-08 05:59:30] scan | 0 routes, 0 models, 40 components → 4 articles
 
 ## [2026-05-08 06:54:32] scan | 0 routes, 0 models, 40 components → 4 articles
+
+## [2026-05-08 06:59:47] scan | 0 routes, 0 models, 40 components → 4 articles

--- a/.codesight/wiki/log.md
+++ b/.codesight/wiki/log.md
@@ -2,8 +2,6 @@
 
 History of `npx codesight --wiki` runs. Capped at 20 entries.
 
-## [2026-05-04 10:36:16] scan | 0 routes, 0 models, 39 components → 4 articles
-
 ## [2026-05-04 11:14:23] scan | 0 routes, 0 models, 39 components → 4 articles
 
 ## [2026-05-04 11:14:52] scan | 0 routes, 0 models, 39 components → 4 articles
@@ -41,3 +39,5 @@ History of `npx codesight --wiki` runs. Capped at 20 entries.
 ## [2026-05-08 05:58:47] scan | 0 routes, 0 models, 40 components → 4 articles
 
 ## [2026-05-08 05:59:30] scan | 0 routes, 0 models, 40 components → 4 articles
+
+## [2026-05-08 06:54:32] scan | 0 routes, 0 models, 40 components → 4 articles

--- a/.codesight/wiki/log.md
+++ b/.codesight/wiki/log.md
@@ -2,10 +2,6 @@
 
 History of `npx codesight --wiki` runs. Capped at 20 entries.
 
-## [2026-05-03 12:32:03] scan | 0 routes, 0 models, 39 components → 4 articles
-
-## [2026-05-04 10:30:43] scan | 0 routes, 0 models, 39 components → 4 articles
-
 ## [2026-05-04 10:36:16] scan | 0 routes, 0 models, 39 components → 4 articles
 
 ## [2026-05-04 11:14:23] scan | 0 routes, 0 models, 39 components → 4 articles
@@ -41,3 +37,7 @@ History of `npx codesight --wiki` runs. Capped at 20 entries.
 ## [2026-05-07 19:49:36] scan | 0 routes, 0 models, 39 components → 4 articles
 
 ## [2026-05-08 05:52:12] scan | 0 routes, 0 models, 39 components → 4 articles
+
+## [2026-05-08 05:58:47] scan | 0 routes, 0 models, 40 components → 4 articles
+
+## [2026-05-08 05:59:30] scan | 0 routes, 0 models, 40 components → 4 articles

--- a/.codesight/wiki/overview.md
+++ b/.codesight/wiki/overview.md
@@ -6,9 +6,9 @@
 
 ## Scale
 
-39 UI components · 59 library files · 1 middleware layers · 3 environment variables
+40 UI components · 59 library files · 1 middleware layers · 3 environment variables
 
-**UI:** 39 components (react) — see [ui.md](./ui.md)
+**UI:** 40 components (react) — see [ui.md](./ui.md)
 
 **Libraries:** 59 files — see [libraries.md](./libraries.md)
 
@@ -16,10 +16,10 @@
 
 Changes to these files have the widest blast radius across the codebase:
 
-- `src\utils\theme.ts` — imported by **39** files
-- `src\store\useAppStore.ts` — imported by **33** files
+- `src\utils\theme.ts` — imported by **40** files
+- `src\store\useAppStore.ts` — imported by **34** files
 - `src\notifications\notificationManager.ts` — imported by **15** files
-- `src\detection\PermissionService.ts` — imported by **13** files
+- `src\detection\PermissionService.ts` — imported by **14** files
 - `src\storage\StorageService.ts` — imported by **11** files
 - `src\components\ResponsiveGridList.tsx` — imported by **11** files
 

--- a/.codesight/wiki/ui.md
+++ b/.codesight/wiki/ui.md
@@ -2,7 +2,7 @@
 
 > **Navigation aid.** Component inventory and prop signatures extracted via AST. Read the source files before adding props or modifying component logic.
 
-**39 components** (react)
+**40 components** (react)
 
 ## Components
 
@@ -40,6 +40,7 @@
 - **HomeScreen** — `src\screens\HomeScreen.tsx`
 - **IntroScreen** — props: onComplete — `src\screens\IntroScreen.tsx`
 - **KnownLocationsScreen** — `src\screens\KnownLocationsScreen.tsx`
+- **Migration180Screen** — props: onComplete — `src\screens\Migration180Screen.tsx`
 - **ScheduledNotificationsScreen** — `src\screens\ScheduledNotificationsScreen.tsx`
 - **SettingsScreen** — `src\screens\SettingsScreen.tsx`
 - **WeatherSettingsScreen** — `src\screens\WeatherSettingsScreen.tsx`

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,14 +2,14 @@
 
 **Stack:** raw-http | none | typescript
 
-0 routes | 0 models | 3 env vars | 431 import links
+0 routes | 0 models | 3 env vars | 437 import links
 
 
 **High-impact files** (change carefully):
-- src\utils\theme.ts (imported by 39 files)
-- src\store\useAppStore.ts (imported by 33 files)
+- src\utils\theme.ts (imported by 40 files)
+- src\store\useAppStore.ts (imported by 34 files)
 - src\notifications\notificationManager.ts (imported by 15 files)
-- src\detection\PermissionService.ts (imported by 13 files)
+- src\detection\PermissionService.ts (imported by 14 files)
 - src\storage\StorageService.ts (imported by 11 files)
 
 **Required env vars:** EAS_BUILD_PROFILE, EXPO_PUBLIC_SHOW_DEV_MENU, NODE_ENV

--- a/App.tsx
+++ b/App.tsx
@@ -12,6 +12,7 @@ import 'expo-dev-client';
 import AppNavigator from './src/navigation/AppNavigator';
 import { useForegroundSync } from './src/hooks/useForegroundSync';
 import IntroScreen from './src/screens/IntroScreen';
+import Migration180Screen from './src/screens/Migration180Screen';
 import UpdateSplashScreen from './src/components/UpdateSplashScreen';
 import { useOTAUpdates } from './src/hooks/useOTAUpdates';
 import { AppProviders } from './src/components/AppProviders';
@@ -23,7 +24,9 @@ function AppContent() {
   const colors = useAppStore((state) => state.colors);
   const isReady = useAppStore((state) => state.isReady);
   const showIntro = useAppStore((state) => state.showIntro);
+  const showMigration180 = useAppStore((state) => state.showMigration180);
   const handleIntroComplete = useAppStore((state) => state.handleIntroComplete);
+  const handleMigration180Complete = useAppStore((state) => state.handleMigration180Complete);
   const initialize = useAppStore((state) => state.initialize);
   const setSystemColorScheme = useAppStore((state) => state.setSystemColorScheme);
 
@@ -68,6 +71,10 @@ function AppContent() {
 
   if (showIntro) {
     return <IntroScreen onComplete={handleIntroComplete} />;
+  }
+
+  if (showMigration180) {
+    return <Migration180Screen onComplete={handleMigration180Complete} />;
   }
 
   return <AppNavigator initialState={savedNavState.current} onStateChange={handleStateChange} />;

--- a/appBootstrap.ts
+++ b/appBootstrap.ts
@@ -13,6 +13,7 @@ import { requestWidgetRefresh } from './src/utils/widgetHelper';
 
 export interface CriticalAppState {
   showIntro: boolean;
+  showMigration180: boolean;
   initialLocale: string;
 }
 
@@ -44,9 +45,11 @@ export async function performCriticalInitializationAsync(): Promise<CriticalAppS
 
   // Check if user has completed intro
   const hasCompletedIntro = (await getSettingAsync('hasCompletedIntro', '0')) === '1';
+  const hasSeenMigration180 = (await getSettingAsync('hasSeenMigration180', '0')) === '1';
 
   return {
     showIntro: !hasCompletedIntro,
+    showMigration180: hasCompletedIntro && !hasSeenMigration180,
     initialLocale,
   };
 }

--- a/src/__tests__/appBootstrap.test.ts
+++ b/src/__tests__/appBootstrap.test.ts
@@ -98,6 +98,7 @@ describe('services/appBootstrap', () => {
       expect(i18n.locale).toBe('nl');
       expect(result).toEqual({
         showIntro: false,
+        showMigration180: true,
         initialLocale: 'nl',
       });
     });
@@ -115,6 +116,7 @@ describe('services/appBootstrap', () => {
 
       expect(i18n.locale).toBe('nl');
       expect(result.initialLocale).toBe('system');
+      expect(result.showMigration180).toBe(false);
     });
 
     it('handles invalid language asynchronously', async () => {
@@ -131,6 +133,7 @@ describe('services/appBootstrap', () => {
       expect(i18n.locale).toBe('en');
       expect(setSettingAsync).toHaveBeenCalledWith('language', 'en');
       expect(result.initialLocale).toBe('en');
+      expect(result.showMigration180).toBe(true);
     });
   });
 

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -293,6 +293,16 @@ const en = {
   manual_invalid_body:
     'Please make sure the end time is after the start time and the session is under 12 hours.',
 
+  // Migration 1.8.0
+  migration_180_title: 'TouchGrass 1.8.0',
+  migration_180_body:
+    "We've completely rebuilt how TouchGrass tracks your time outside. It's now much more battery efficient and accurate!",
+  migration_180_battery_title: 'Re-enable Battery Optimization',
+  migration_180_battery_body:
+    'Because the new tracking is so efficient, you no longer need to disable battery optimization for TouchGrass. You can safely turn it back on to save battery!',
+  migration_180_battery_button: 'Open Battery Settings',
+  migration_180_continue_button: 'Continue',
+
   // Intro/Onboarding
   intro_skip: 'Skip',
   intro_next: 'Next',

--- a/src/i18n/nl.ts
+++ b/src/i18n/nl.ts
@@ -288,6 +288,16 @@ const nl: TranslationType = {
   manual_invalid_title: 'Ongeldige tijd',
   manual_invalid_body: 'Zorg dat de sessie korter dan 12 uur is.',
 
+  // Migration 1.8.0
+  migration_180_title: 'TouchGrass 1.8.0',
+  migration_180_body:
+    'We hebben de manier waarop TouchGrass je tijd buiten bijhoudt volledig opnieuw gebouwd. Het is nu veel batterijvriendelijker en nauwkeuriger!',
+  migration_180_battery_title: 'Batterij-optimalisatie opnieuw inschakelen',
+  migration_180_battery_body:
+    'Omdat de nieuwe manier van bijhouden zo efficiënt is, hoef je de batterij-optimalisatie voor TouchGrass niet meer uit te schakelen. Je kunt deze veilig weer aanzetten om batterij te besparen!',
+  migration_180_battery_button: 'Open Batterij-instellingen',
+  migration_180_continue_button: 'Doorgaan',
+
   // Intro/Onboarding
   intro_skip: 'Overslaan',
   intro_next: 'Volgende',

--- a/src/screens/Migration180Screen.tsx
+++ b/src/screens/Migration180Screen.tsx
@@ -1,0 +1,269 @@
+import React, { useState, useMemo, useEffect, useCallback } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  TouchableOpacity,
+  Platform,
+  ActivityIndicator,
+  AppState,
+  AppStateStatus,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useAppStore } from '../store/useAppStore';
+import { t } from '../i18n';
+import { radius, spacing, ThemeColors, Shadows } from '../utils/theme';
+import { Card } from '../components/ui';
+import { toggleAR } from '../detection/index';
+import { PermissionService } from '../detection/PermissionService';
+import { ActivityTransitionModule } from '../modules/ActivityTransitionModule';
+import * as IntentLauncher from 'expo-intent-launcher';
+import { setSettingAsync } from '../storage';
+
+interface Props {
+  onComplete: () => void;
+}
+
+export default function Migration180Screen({ onComplete }: Props) {
+  const colors = useAppStore((state) => state.colors);
+  const shadows = useAppStore((state) => state.shadows);
+  const styles = useMemo(() => makeStyles(colors, shadows), [colors, shadows]);
+
+  const [activityRecognitionGranted, setActivityRecognitionGranted] = useState(false);
+  const [requestingPermission, setRequestingPermission] = useState(false);
+
+  const checkPermissions = useCallback(async () => {
+    if (Platform.OS === 'android') {
+      const arGranted = await PermissionService.checkActivityRecognitionPermissions();
+      setActivityRecognitionGranted(arGranted);
+    } else {
+      setActivityRecognitionGranted(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    checkPermissions();
+  }, [checkPermissions]);
+
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', (state: AppStateStatus) => {
+      if (state === 'active') {
+        checkPermissions();
+      }
+    });
+    return () => subscription.remove();
+  }, [checkPermissions]);
+
+  const handleRequestActivityRecognition = async () => {
+    setRequestingPermission(true);
+    try {
+      const result = await toggleAR(true);
+      if (result.needsPermissions) {
+        const { granted } = await PermissionService.requestActivityRecognitionPermissions();
+        setActivityRecognitionGranted(granted);
+        if (granted) {
+          await ActivityTransitionModule.startTracking();
+        }
+      } else {
+        setActivityRecognitionGranted(true);
+      }
+    } catch (error) {
+      console.error('Error requesting Activity Recognition:', error);
+    } finally {
+      setRequestingPermission(false);
+    }
+  };
+
+  const handleOpenBatterySettings = async () => {
+    if (Platform.OS === 'android') {
+      try {
+        await IntentLauncher.startActivityAsync(
+          'android.settings.IGNORE_BATTERY_OPTIMIZATION_SETTINGS'
+        );
+      } catch (e) {
+        console.warn('Could not open battery optimization settings', e);
+      }
+    }
+  };
+
+  const handleComplete = async () => {
+    if (activityRecognitionGranted) {
+      await setSettingAsync('ar_enabled', '1');
+    }
+    onComplete();
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <ScrollView style={styles.content} contentContainerStyle={styles.contentInner}>
+        <View style={styles.stepContainer}>
+          <Text style={styles.emoji}>🚀</Text>
+          <Text style={styles.title}>TouchGrass 1.8.0</Text>
+          <Text style={styles.body}>
+            We&apos;ve completely rebuilt how TouchGrass tracks your time outside. It&apos;s now
+            much more battery efficient and accurate!
+          </Text>
+
+          {/* Activity Recognition Card */}
+          <Card style={styles.card}>
+            <Text style={styles.cardEmoji}>🔋</Text>
+            <Text style={styles.cardTitle}>{t('intro_ar_title')}</Text>
+            <Text style={styles.cardBody}>{t('intro_ar_body')}</Text>
+
+            <TouchableOpacity
+              style={[
+                styles.actionButton,
+                activityRecognitionGranted && styles.actionButtonGranted,
+              ]}
+              onPress={handleRequestActivityRecognition}
+              disabled={activityRecognitionGranted || requestingPermission}
+            >
+              {requestingPermission ? (
+                <ActivityIndicator size="small" color={colors.textInverse} />
+              ) : (
+                <Text style={styles.actionButtonText}>
+                  {activityRecognitionGranted ? t('intro_ar_button_granted') : t('intro_ar_button')}
+                </Text>
+              )}
+            </TouchableOpacity>
+          </Card>
+
+          {/* Battery Optimization Card */}
+          {Platform.OS === 'android' && (
+            <Card style={styles.card}>
+              <Text style={styles.cardEmoji}>⚙️</Text>
+              <Text style={styles.cardTitle}>Re-enable Battery Optimization</Text>
+              <Text style={styles.cardBody}>
+                Because the new tracking is so efficient, you no longer need to disable battery
+                optimization for TouchGrass. You can safely turn it back on to save battery!
+              </Text>
+
+              <TouchableOpacity style={styles.outlineButton} onPress={handleOpenBatterySettings}>
+                <Text style={styles.outlineButtonText}>Open Battery Settings</Text>
+              </TouchableOpacity>
+            </Card>
+          )}
+        </View>
+      </ScrollView>
+
+      <View style={styles.footer}>
+        <TouchableOpacity style={styles.nextBtn} onPress={handleComplete}>
+          <Text style={styles.nextBtnText}>Continue</Text>
+        </TouchableOpacity>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const makeStyles = (colors: ThemeColors, shadows: Shadows) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: colors.mist,
+    },
+    content: {
+      flex: 1,
+    },
+    contentInner: {
+      padding: spacing.xl,
+      paddingBottom: spacing.xxl * 2,
+    },
+    stepContainer: {
+      flex: 1,
+      alignItems: 'center',
+    },
+    emoji: {
+      fontSize: 64,
+      marginBottom: spacing.md,
+      textAlign: 'center',
+    },
+    title: {
+      fontSize: 28,
+      fontWeight: '800',
+      color: colors.textPrimary,
+      marginBottom: spacing.md,
+      textAlign: 'center',
+    },
+    body: {
+      fontSize: 16,
+      color: colors.textSecondary,
+      textAlign: 'center',
+      lineHeight: 24,
+      marginBottom: spacing.xl,
+    },
+    card: {
+      width: '100%',
+      padding: spacing.lg,
+      marginBottom: spacing.lg,
+      alignItems: 'center',
+    },
+    cardEmoji: {
+      fontSize: 32,
+      marginBottom: spacing.sm,
+    },
+    cardTitle: {
+      fontSize: 18,
+      fontWeight: '700',
+      color: colors.textPrimary,
+      marginBottom: spacing.sm,
+      textAlign: 'center',
+    },
+    cardBody: {
+      fontSize: 14,
+      color: colors.textSecondary,
+      textAlign: 'center',
+      lineHeight: 20,
+      marginBottom: spacing.lg,
+    },
+    actionButton: {
+      backgroundColor: colors.grass,
+      paddingVertical: spacing.md,
+      paddingHorizontal: spacing.xl,
+      borderRadius: radius.full,
+      width: '100%',
+      alignItems: 'center',
+      ...shadows.soft,
+    },
+    actionButtonGranted: {
+      backgroundColor: colors.textMuted,
+    },
+    actionButtonText: {
+      color: colors.textInverse,
+      fontSize: 16,
+      fontWeight: '700',
+    },
+    outlineButton: {
+      backgroundColor: 'transparent',
+      borderWidth: 2,
+      borderColor: colors.grass,
+      paddingVertical: spacing.md,
+      paddingHorizontal: spacing.xl,
+      borderRadius: radius.full,
+      width: '100%',
+      alignItems: 'center',
+    },
+    outlineButtonText: {
+      color: colors.grass,
+      fontSize: 16,
+      fontWeight: '700',
+    },
+    footer: {
+      padding: spacing.xl,
+      backgroundColor: colors.card,
+      borderTopWidth: 1,
+      borderTopColor: colors.fog,
+    },
+    nextBtn: {
+      backgroundColor: colors.textPrimary,
+      paddingVertical: spacing.lg,
+      borderRadius: radius.full,
+      alignItems: 'center',
+      ...shadows.medium,
+    },
+    nextBtnText: {
+      color: colors.textInverse,
+      fontSize: 16,
+      fontWeight: '800',
+    },
+  });

--- a/src/screens/Migration180Screen.tsx
+++ b/src/screens/Migration180Screen.tsx
@@ -99,11 +99,8 @@ export default function Migration180Screen({ onComplete }: Props) {
       <ScrollView style={styles.content} contentContainerStyle={styles.contentInner}>
         <View style={styles.stepContainer}>
           <Text style={styles.emoji}>🚀</Text>
-          <Text style={styles.title}>TouchGrass 1.8.0</Text>
-          <Text style={styles.body}>
-            We&apos;ve completely rebuilt how TouchGrass tracks your time outside. It&apos;s now
-            much more battery efficient and accurate!
-          </Text>
+          <Text style={styles.title}>{t('migration_180_title')}</Text>
+          <Text style={styles.body}>{t('migration_180_body')}</Text>
 
           {/* Activity Recognition Card */}
           <Card style={styles.card}>
@@ -133,14 +130,11 @@ export default function Migration180Screen({ onComplete }: Props) {
           {Platform.OS === 'android' && (
             <Card style={styles.card}>
               <Text style={styles.cardEmoji}>⚙️</Text>
-              <Text style={styles.cardTitle}>Re-enable Battery Optimization</Text>
-              <Text style={styles.cardBody}>
-                Because the new tracking is so efficient, you no longer need to disable battery
-                optimization for TouchGrass. You can safely turn it back on to save battery!
-              </Text>
+              <Text style={styles.cardTitle}>{t('migration_180_battery_title')}</Text>
+              <Text style={styles.cardBody}>{t('migration_180_battery_body')}</Text>
 
               <TouchableOpacity style={styles.outlineButton} onPress={handleOpenBatterySettings}>
-                <Text style={styles.outlineButtonText}>Open Battery Settings</Text>
+                <Text style={styles.outlineButtonText}>{t('migration_180_battery_button')}</Text>
               </TouchableOpacity>
             </Card>
           )}
@@ -149,7 +143,7 @@ export default function Migration180Screen({ onComplete }: Props) {
 
       <View style={styles.footer}>
         <TouchableOpacity style={styles.nextBtn} onPress={handleComplete}>
-          <Text style={styles.nextBtnText}>Continue</Text>
+          <Text style={styles.nextBtnText}>{t('migration_180_continue_button')}</Text>
         </TouchableOpacity>
       </View>
     </SafeAreaView>

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -168,6 +168,12 @@ export default function SettingsScreen() {
     Alert.alert('Dev Menu', 'dayPlanLastDate cleared. Reminders will re-plan on next trigger.');
   }, []);
 
+  const handleResetMigration180 = useCallback(async () => {
+    await setSettingAsync('hasSeenMigration180', '0');
+    useAppStore.setState({ showMigration180: true });
+    Alert.alert('Developer Mode', 'Migration 180 state reset. You will see the tutorial again.');
+  }, []);
+
   const handleToggleDevForceHalfHour = useCallback(async () => {
     const newValue = !devForceHalfHour;
     setDevForceHalfHour(newValue);
@@ -524,6 +530,16 @@ export default function SettingsScreen() {
                     icon={<Ionicons name="bug-outline" size={20} color={colors.textSecondary} />}
                     label="Clear dayPlanLastDate"
                     sublabel="Force re-planning of today's reminders"
+                  />
+                </TouchableOpacity>
+                <Divider />
+                <TouchableOpacity onPress={handleResetMigration180}>
+                  <SettingRow
+                    icon={
+                      <Ionicons name="refresh-outline" size={20} color={colors.textSecondary} />
+                    }
+                    label="Reset Migration 1.8.0 Tutorial"
+                    sublabel="Show the 1.8.0 migration screen again"
                   />
                 </TouchableOpacity>
                 <Divider />

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -33,8 +33,9 @@ export interface AppState {
   // Language
   locale: string;
 
-  // Intro
+  // Intro & Migration
   showIntro: boolean;
+  showMigration180: boolean;
 
   // Theme
   themePreference: ThemePreference;
@@ -52,6 +53,7 @@ export interface AppState {
   setLocale: (code: string) => void;
   handleShowIntro: () => void;
   handleIntroComplete: () => void;
+  handleMigration180Complete: () => void;
   setThemePreference: (pref: ThemePreference) => void;
   setSystemColorScheme: (scheme: ColorSchemeName) => void;
   dismissFeedback: () => void;
@@ -71,6 +73,7 @@ const initialState = {
   deferredInitDone: false,
   locale: 'system',
   showIntro: true,
+  showMigration180: false,
   themePreference: 'system' as ThemePreference,
   systemColorScheme: 'light' as ColorSchemeName,
   colors: lightColors,
@@ -85,8 +88,11 @@ export const useAppStore = create<AppState>((set, get) => ({
 
   initialize: async (systemScheme: ColorSchemeName) => {
     try {
-      const { showIntro: initialShowIntro, initialLocale } =
-        await performCriticalInitializationAsync();
+      const {
+        showIntro: initialShowIntro,
+        showMigration180: initialShowMigration180,
+        initialLocale,
+      } = await performCriticalInitializationAsync();
 
       const storedTheme = await getSettingAsync('theme_preference', 'system');
       const themePref =
@@ -99,6 +105,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       set({
         isReady: true,
         showIntro: initialShowIntro,
+        showMigration180: initialShowMigration180,
         locale: initialLocale,
         themePreference: themePref,
         systemColorScheme: systemScheme,
@@ -106,7 +113,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       });
 
       // Trigger deferred init if not showing intro
-      if (!initialShowIntro) {
+      if (!initialShowIntro && !initialShowMigration180) {
         set({ deferredInitDone: true });
         performDeferredInitialization();
       }
@@ -139,6 +146,22 @@ export const useAppStore = create<AppState>((set, get) => ({
 
     const { deferredInitDone } = get();
     set({ showIntro: false });
+    // Also mark migration as seen so new users don't see both
+    setSettingAsync('hasSeenMigration180', '1').catch(() => {});
+
+    if (!deferredInitDone) {
+      set({ deferredInitDone: true });
+      performDeferredInitialization();
+    }
+  },
+
+  handleMigration180Complete: () => {
+    setSettingAsync('hasSeenMigration180', '1').catch((err) =>
+      console.error('[AppStore] Failed to save migration completion:', err)
+    );
+
+    const { deferredInitDone } = get();
+    set({ showMigration180: false });
 
     if (!deferredInitDone) {
       set({ deferredInitDone: true });

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -146,8 +146,9 @@ export const useAppStore = create<AppState>((set, get) => ({
 
     const { deferredInitDone } = get();
     set({ showIntro: false });
-    // Also mark migration as seen so new users don't see both
-    setSettingAsync('hasSeenMigration180', '1').catch(() => {});
+    setSettingAsync('hasSeenMigration180', '1').catch((err) =>
+      console.error('[AppStore] Failed to save migration status for new user:', err)
+    );
 
     if (!deferredInitDone) {
       set({ deferredInitDone: true });


### PR DESCRIPTION
Resolves #465  https://github.com/sanderw-be/TouchGrass/issues/465.

This PR adds a one-time migration tutorial screen (Migration180Screen) for users upgrading to TouchGrass 1.8.0.

Key Additions:

Migration180Screen: Explains the new tracking mechanism, requests Activity Recognition permissions, and provides a button to re-enable battery optimization directly in Android settings.
State Management: Updated useAppStore and appBootstrap to track the showMigration180 state using the hasSeenMigration180 persistent setting.
Routing: App.tsx now conditionally renders the migration screen after initialization if the user has completed the original intro but hasn't seen the migration prompt.